### PR TITLE
Change how the cards UI is displayed when there are none.

### DIFF
--- a/src/components/DisplayBox/DisplayBox.js
+++ b/src/components/DisplayBox/DisplayBox.js
@@ -363,13 +363,22 @@ export default class DisplayBox extends Component{
       
               renderedCards.push(builtCard);
             });
+
+            if (renderedCards.length === 0) {
+              return <div>
+                      Nofication Cards ({renderedCards.length})
+                      </div>;
+            }
+            return <div>
+                    Nofication Cards ({renderedCards.length})
+                    <div>
+                      {renderedCards}
+                    </div>
+                  </div>;
+          } else {
+            return <div>
+                  </div>;
           }
-          if (renderedCards.length === 0) { return <div><div className='decision-card alert-warning'>No Cards</div></div>; }
-          return <div>
-                  <div>
-                  {renderedCards}
-                  </div>
-                </div>;
         }
 
         componentDidUpdate() {

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -148,6 +148,7 @@ export default class RequestBuilder extends Component {
             }).then(response => {
                 clearTimeout(this.timeout)
                 response.json().then((fhirResponse) => {
+                    console.log(fhirResponse);
                     if (fhirResponse && fhirResponse.status) {
                         this.consoleLog("Server returned status "
                             + fhirResponse.status + ": "

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -161,6 +161,7 @@ export default class RequestBuilder extends Component {
                 })
             }).catch(() => {
                 this.consoleLog("No response received from the server", types.error);
+                this.setState({ response: null });
                 this.setState({loading: false});
             });
         } catch (error) {


### PR DESCRIPTION
## Describe your changes

Update the request generator UI to not show the cards area when the application launches and there are no cards to show. Then when there is a return from the CDS Hook call, show the number of cards above any cards to display. If there are none, "Notification Cards (0)" will display.

## Issue ticket number and Jira link

https://jira.mitre.org/browse/REMS-508

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Ensure the target / base branch for any feature PR is set to `dev` not main (the only exception to this is releases from `dev` and hotfix branches)

## Checklist for conducting a review
- [ ] Review the code changes and make sure they all make sense and are necessary. 
- [ ] Pull the PR branch locally and test by running through workflow and making sure everything works as it is supposed to. 

## Workflow 

Owner of the Pull Request will be responsible for merge after all requirements are met, including approval from at least one reviewer. Additional changes made after a review will dismiss any approvals and require re-review of the additional updates. Auto merging can be enabled below if additional changes are likely not to be needed. The bot will auto assign reviewers to your Pull Request for you. 

