### PR TITLE
add smart launch

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 
 REACT_APP_REALM = ClientFhirServer
 REACT_APP_CLIENT = app-login
-REACT_APP_CLIENT_SCOPES = launch openid profile user/Patient.read patient/Patient.read user/Practitioner.read
+REACT_APP_CLIENT_SCOPES = launch offline_access openid profile user/Patient.read patient/Patient.read user/Practitioner.read
 REACT_APP_AUTH = http://localhost:8180
 REACT_APP_SERVER = http://localhost:8090
 REACT_APP_EHR_SERVER = http://localhost:8080/test-ehr/r4

--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@
 
 REACT_APP_REALM = ClientFhirServer
 REACT_APP_CLIENT = app-login
+REACT_APP_CLIENT_SCOPES = launch openid profile user/Patient.read patient/Patient.read user/Practitioner.read
 REACT_APP_AUTH = http://localhost:8180
 REACT_APP_SERVER = http://localhost:8090
 REACT_APP_EHR_SERVER = http://localhost:8080/test-ehr/r4

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route}
-    from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import RequestBuilder from '../containers/RequestBuilder';
 import PatientPortal from '../containers/PatientPortal';
 import theme from '../containers/styles/theme';
@@ -9,21 +8,24 @@ import Launch from '../containers/Launch';
 import Index from '../containers/Index';
 const Router = (process.env.REACT_APP_GH_PAGES === 'true') ? HashRouter : BrowserRouter;
 const App = () => {
-        return (
-                <Router>
-                    <Routes>
-                        <Route path='/' exact element={<RequestBuilder />} />
-                        <Route exact path='/launch' element={<Launch />} />
-                        <Route exact path='/index' element={<Index />} />
-                        <Route exact path='/patient-portal' element={
-                        <ThemeProvider theme={theme}>
-                            <PatientPortal />
-                        </ThemeProvider>} />
-
-                    </Routes>
-                </Router>
-        );
-    
-}
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" exact element={<RequestBuilder />} />
+        <Route exact path="/launch" element={<Launch />} />
+        <Route exact path="/index" element={<Index />} />
+        <Route
+          exact
+          path="/patient-portal"
+          element={
+            <ThemeProvider theme={theme}>
+              <PatientPortal />
+            </ThemeProvider>
+          }
+        />
+      </Routes>
+    </Router>
+  );
+};
 
 export default App;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,28 +1,31 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter , HashRouter , Routes, Route } from 'react-router-dom';
 import RequestBuilder from '../containers/RequestBuilder';
 import PatientPortal from '../containers/PatientPortal';
 import theme from '../containers/styles/theme';
 import { ThemeProvider } from '@mui/styles';
 import Launch from '../containers/Launch';
 import Index from '../containers/Index';
-const Router = (process.env.REACT_APP_GH_PAGES === 'true') ? HashRouter : BrowserRouter;
+
+const isGhPages = process.env.REACT_APP_GH_PAGES === 'true';
+const Router = isGhPages ? HashRouter : BrowserRouter;
+const redirect = isGhPages ? '/#/index' : '/index';
 const App = () => {
   return (
     <Router>
       <Routes>
-        <Route path="/" exact element={<RequestBuilder />} />
-        <Route exact path="/launch" element={<Launch />} />
-        <Route exact path="/index" element={<Index />} />
+        <Route path='/launch' element={<Launch redirect={redirect} />} />
+        <Route path='/index' element={<Index />} />
         <Route
-          exact
-          path="/patient-portal"
+          path='/patient-portal'
           element={
             <ThemeProvider theme={theme}>
               <PatientPortal />
             </ThemeProvider>
           }
         />
+        <Route path="/" exact element={<RequestBuilder redirect = {redirect} />} />
+
       </Routes>
     </Router>
   );

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,30 +1,29 @@
-import React, { Component } from 'react';
-import { BrowserRouter , HashRouter , Routes, Route } from 'react-router-dom';
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route}
+    from 'react-router-dom';
 import RequestBuilder from '../containers/RequestBuilder';
 import PatientPortal from '../containers/PatientPortal';
 import theme from '../containers/styles/theme';
 import { ThemeProvider } from '@mui/styles';
-
+import Launch from '../containers/Launch';
+import Index from '../containers/Index';
 const Router = (process.env.REACT_APP_GH_PAGES === 'true') ? HashRouter : BrowserRouter;
+const App = () => {
+        return (
+                <Router>
+                    <Routes>
+                        <Route path='/' exact element={<RequestBuilder />} />
+                        <Route exact path='/launch' element={<Launch />} />
+                        <Route exact path='/index' element={<Index callback = {setClient}/>} />
+                        <Route exact path='/patient-portal' element={
+                        <ThemeProvider theme={theme}>
+                            <PatientPortal />
+                        </ThemeProvider>} />
 
-export default class App extends Component {
-  render() {
-    return (
-      <Router >
-        <Routes>
-          <Route path="/" exact element={<RequestBuilder />} />
-
-          <Route
-            exact
-            path="/patient-portal"
-            element={
-              <ThemeProvider theme={theme}>
-                <PatientPortal />
-              </ThemeProvider>
-            }
-          />
-        </Routes>
-      </Router>
-    );
-  }
+                    </Routes>
+                </Router>
+        );
+    
 }
+
+export default App;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -14,7 +14,7 @@ const App = () => {
                     <Routes>
                         <Route path='/' exact element={<RequestBuilder />} />
                         <Route exact path='/launch' element={<Launch />} />
-                        <Route exact path='/index' element={<Index callback = {setClient}/>} />
+                        <Route exact path='/index' element={<Index />} />
                         <Route exact path='/patient-portal' element={
                         <ThemeProvider theme={theme}>
                             <PatientPortal />

--- a/src/components/ConsoleBox/ConsoleBox.js
+++ b/src/components/ConsoleBox/ConsoleBox.js
@@ -36,7 +36,9 @@ export default class ConsoleBox extends Component {
   render() {
     try {
       var objDiv = document.getElementById('your_div');
-      objDiv.scrollTop = objDiv.scrollHeight;
+      if(objDiv) {
+        objDiv.scrollTop = objDiv.scrollHeight;
+      }
     } catch (error) {
       console.log('Encountered error', error);
     }

--- a/src/components/ConsoleBox/ConsoleBox.js
+++ b/src/components/ConsoleBox/ConsoleBox.js
@@ -36,7 +36,7 @@ export default class ConsoleBox extends Component {
   render() {
     try {
       var objDiv = document.getElementById('your_div');
-      if(objDiv) {
+      if (objDiv) {
         objDiv.scrollTop = objDiv.scrollHeight;
       }
     } catch (error) {

--- a/src/components/Dashboard/DashboardElement.jsx
+++ b/src/components/Dashboard/DashboardElement.jsx
@@ -25,17 +25,11 @@ const DashboardElement = props => {
       appContext: encodeURIComponent(`response=QuestionnaireResponse/${resource.id}`),
       type: 'smart',
       url: env.get('REACT_APP_LAUNCH_URL').asString()
-    };
-    retrieveLaunchContext(
-      link,
-      clientState.tokenResponse.accessToken,
-      clientState.tokenResponse.patient,
-      clientState.serverUrl,
-      'r4'
-    ).then(e => {
-      window.open(e.url, '_blank');
-    });
-  };
+    }
+    retrieveLaunchContext(link, clientState.tokenResponse.patient, clientState).then((e) => {
+      window.open(e.url, "_blank");
+    })
+  }
   const renderStatus = () => {
     let bColor = {};
     if (status === 'in-progress') {

--- a/src/components/Dashboard/DashboardElement.jsx
+++ b/src/components/Dashboard/DashboardElement.jsx
@@ -25,11 +25,11 @@ const DashboardElement = props => {
       appContext: encodeURIComponent(`response=QuestionnaireResponse/${resource.id}`),
       type: 'smart',
       url: env.get('REACT_APP_LAUNCH_URL').asString()
-    }
-    retrieveLaunchContext(link, clientState.tokenResponse.patient, clientState).then((e) => {
-      window.open(e.url, "_blank");
-    })
-  }
+    };
+    retrieveLaunchContext(link, clientState.tokenResponse.patient, clientState).then(e => {
+      window.open(e.url, '_blank');
+    });
+  };
   const renderStatus = () => {
     let bColor = {};
     if (status === 'in-progress') {

--- a/src/components/DisplayBox/DisplayBox.js
+++ b/src/components/DisplayBox/DisplayBox.js
@@ -114,28 +114,21 @@ export default class DisplayBox extends Component {
           });
         }
 
-        const client = FHIR.client({
-          serverUrl: this.props.ehrUrl,
-          tokenResponse: {
-            access_token: this.props.access_token.access_token
-          }
-        });
-
         // handle each action from the suggestion
         var uri = '';
-        suggestion.actions.forEach(action => {
-          if (action.type.toUpperCase() === 'DELETE') {
-            uri = action.resource.resourceType + '/' + action.resource.id;
-            console.log('completing suggested action DELETE: ' + uri);
-            client.delete(uri).then(result => {
-              console.log('suggested action DELETE result:');
+        suggestion.actions.forEach((action) => {
+          if (action.type.toUpperCase() === "DELETE") {
+            uri = action.resource.resourceType + "/" + action.resource.id;
+            console.log("completing suggested action DELETE: " + uri);
+            this.props.client.delete(uri).then((result) => {
+              console.log("suggested action DELETE result:");
               console.log(result);
             });
           } else if (action.type.toUpperCase() === 'CREATE') {
             uri = action.resource.resourceType;
-            console.log('completing suggested action CREATE: ' + uri);
-            client.create(action.resource).then(result => {
-              console.log('suggested action CREATE result:');
+            console.log("completing suggested action CREATE: " + uri);
+            this.props.client.create(action.resource).then((result) => {
+              console.log("suggested action CREATE result:");
               console.log(result);
 
               if (this.supportedRequesType(result)) {
@@ -143,11 +136,12 @@ export default class DisplayBox extends Component {
                 this.props.takeSuggestion(result);
               }
             });
-          } else if (action.type.toUpperCase() === 'UPDATE') {
-            uri = action.resource.resourceType + '/' + action.resource.id;
-            console.log('completing suggested action UPDATE: ' + uri);
-            client.update(action.resource).then(result => {
-              console.log('suggested action UPDATE result:');
+
+          } else if (action.type.toUpperCase() === "UPDATE") {
+            uri = action.resource.resourceType + "/" + action.resource.id;
+            console.log("completing suggested action UPDATE: " + uri);
+            this.props.client.update(action.resource).then((result) => {
+              console.log("suggested action UPDATE result:");
               console.log(result);
             });
           } else {
@@ -207,11 +201,8 @@ export default class DisplayBox extends Component {
         ) {
           retrieveLaunchContext(
             linkCopy,
-            this.props.fhirAccessToken,
-            this.props.patientId,
-            this.props.fhirServerUrl,
-            this.props.fhirVersion
-          ).then(result => {
+            this.props.patientId, this.props.client.state
+          ).then((result) => {
             linkCopy = result;
             return linkCopy;
           });

--- a/src/components/DisplayBox/DisplayBox.js
+++ b/src/components/DisplayBox/DisplayBox.js
@@ -116,19 +116,19 @@ export default class DisplayBox extends Component {
 
         // handle each action from the suggestion
         var uri = '';
-        suggestion.actions.forEach((action) => {
-          if (action.type.toUpperCase() === "DELETE") {
-            uri = action.resource.resourceType + "/" + action.resource.id;
-            console.log("completing suggested action DELETE: " + uri);
-            this.props.client.delete(uri).then((result) => {
-              console.log("suggested action DELETE result:");
+        suggestion.actions.forEach(action => {
+          if (action.type.toUpperCase() === 'DELETE') {
+            uri = action.resource.resourceType + '/' + action.resource.id;
+            console.log('completing suggested action DELETE: ' + uri);
+            this.props.client.delete(uri).then(result => {
+              console.log('suggested action DELETE result:');
               console.log(result);
             });
           } else if (action.type.toUpperCase() === 'CREATE') {
             uri = action.resource.resourceType;
-            console.log("completing suggested action CREATE: " + uri);
-            this.props.client.create(action.resource).then((result) => {
-              console.log("suggested action CREATE result:");
+            console.log('completing suggested action CREATE: ' + uri);
+            this.props.client.create(action.resource).then(result => {
+              console.log('suggested action CREATE result:');
               console.log(result);
 
               if (this.supportedRequesType(result)) {
@@ -136,12 +136,11 @@ export default class DisplayBox extends Component {
                 this.props.takeSuggestion(result);
               }
             });
-
-          } else if (action.type.toUpperCase() === "UPDATE") {
-            uri = action.resource.resourceType + "/" + action.resource.id;
-            console.log("completing suggested action UPDATE: " + uri);
-            this.props.client.update(action.resource).then((result) => {
-              console.log("suggested action UPDATE result:");
+          } else if (action.type.toUpperCase() === 'UPDATE') {
+            uri = action.resource.resourceType + '/' + action.resource.id;
+            console.log('completing suggested action UPDATE: ' + uri);
+            this.props.client.update(action.resource).then(result => {
+              console.log('suggested action UPDATE result:');
               console.log(result);
             });
           } else {
@@ -199,13 +198,12 @@ export default class DisplayBox extends Component {
           (this.props.fhirAccessToken || this.props.ehrLaunch) &&
           !this.state.smartLink
         ) {
-          retrieveLaunchContext(
-            linkCopy,
-            this.props.patientId, this.props.client.state
-          ).then((result) => {
-            linkCopy = result;
-            return linkCopy;
-          });
+          retrieveLaunchContext(linkCopy, this.props.patientId, this.props.client.state).then(
+            result => {
+              linkCopy = result;
+              return linkCopy;
+            }
+          );
         } else if (link.type === 'smart') {
           if (link.url.indexOf('?') < 0) {
             linkCopy.url += '?';

--- a/src/components/RequestBox/RequestBox.js
+++ b/src/components/RequestBox/RequestBox.js
@@ -16,6 +16,8 @@ const style = {
   left: '50%',
   flexDirection: 'column',
   width: '80%',
+  height: '70%',
+  overflowY: 'scroll',
   transform: 'translate(-50%, -50%)',
   display: 'flex',
   bgcolor: 'background.paper',
@@ -154,15 +156,10 @@ export default class RequestBox extends Component {
 
   getPatients = () => {
     this.setState({ openPatient: true });
-    const params = { serverUrl: this.props.ehrUrl };
-    if (this.props.access_token.access_token) {
-      params['tokenResponse'] = { access_token: this.props.access_token.access_token };
-    }
-    const client = FHIR.client(params);
 
-    client
-      .request('Patient?_sort=identifier&_count=12', { flat: true })
-      .then(result => {
+    this.props.client
+      .request("Patient?_sort=identifier&_count=12", { flat: true })
+      .then((result) => {
         this.setState({
           patientList: result
         });
@@ -343,15 +340,12 @@ export default class RequestBox extends Component {
 
     retrieveLaunchContext(
       link,
-      this.props.fhirAccessToken,
-      this.state.patient.id,
-      this.props.fhirServerUrl,
-      this.props.fhirVersion
-    ).then(result => {
-      link = result;
-      console.log(link);
-      // launch the application in a new window
-      window.open(link.url, '_blank');
+        this.state.patient.id, this.props.client.state
+    ).then((result) => {
+        link = result;
+        console.log(link);
+        // launch the application in a new window
+        window.open(link.url, '_blank');
     });
   };
 
@@ -409,13 +403,10 @@ export default class RequestBox extends Component {
 
     return retrieveLaunchContext(
       linkCopy,
-      this.props.fhirAccessToken,
-      this.state.patient.id,
-      this.props.fhirServerUrl,
-      this.props.fhirVersion
-    ).then(result => {
-      linkCopy = result;
-      return linkCopy;
+        this.state.patient.id, this.props.client.state
+    ).then((result) => {
+        linkCopy = result;
+        return linkCopy;
     });
   }
 
@@ -467,12 +458,7 @@ export default class RequestBox extends Component {
   }
 
   render() {
-    const params = {};
-    params['serverUrl'] = this.props.ehrUrl;
-    if (this.props.access_token) {
-      params['tokenResponse'] = { access_token: this.props.access_token.access_token };
-    }
-    const disableSendToCRD = this.isOrderNotSelected() || this.props.loading;
+    const disableSendToCRD = this.isOrderNotSelected() || this.props.loading ;
     const disableLaunchDTR = !this.state.response.questionnaire;
     const disableSendRx = this.isOrderNotSelected() || this.props.loading;
     const disableLaunchSmartOnFhir = this.isPatientNotSelected();
@@ -483,30 +469,32 @@ export default class RequestBox extends Component {
             open={this.state.openPatient}
             onClose={this.exitSmart}
             aria-labelledby="modal-modal-title"
-            aria-describedby="modal-modal-description"
-          >
-            <Box sx={style}>
-              {this.state.patientList instanceof Error
-                ? this.renderError()
-                : this.state.patientList.map(patient => {
-                    return (
-                      <PatientBox
-                        key={patient.id}
-                        patient={patient}
-                        params={params}
-                        callback={this.updateStateElement}
-                        callbackList={this.updateStateList}
-                        callbackMap={this.updateStateMap}
-                        updatePrefetchCallback={PrefetchTemplate.generateQueries}
-                        clearCallback={this.clearState}
-                        ehrUrl={this.props.ehrUrl}
-                        options={this.state.codeValues}
-                        responseExpirationDays={this.props.responseExpirationDays}
-                        defaultUser={this.props.defaultUser}
-                      />
-                    );
-                  })}
-            </Box>
+            aria-describedby="modal-modal-description">
+              <Box sx={style}>
+                    {this.state.patientList instanceof Error
+                      ? this.renderError()
+                      : this.state.patientList.map((patient) => {
+                          return (
+                            <PatientBox
+                              key={patient.id}
+                              patient={patient}
+                              client={this.props.client}
+                              callback={this.updateStateElement}
+                              callbackList={this.updateStateList}
+                              callbackMap={this.updateStateMap}
+                              updatePrefetchCallback={
+                                PrefetchTemplate.generateQueries
+                              }
+                              clearCallback={this.clearState}
+                              ehrUrl={this.props.ehrUrl}
+                              options={this.state.codeValues}
+                              responseExpirationDays={this.props.responseExpirationDays}
+                              defaultUser={this.props.defaultUser}
+                            />
+                          );
+                        })}
+              </Box>
+
           </Modal>
           <div>
             <Button variant="contained" onClick={this.getPatients} startIcon={<PersonIcon />}>

--- a/src/components/RequestBox/RequestBox.js
+++ b/src/components/RequestBox/RequestBox.js
@@ -158,8 +158,8 @@ export default class RequestBox extends Component {
     this.setState({ openPatient: true });
 
     this.props.client
-      .request("Patient?_sort=identifier&_count=12", { flat: true })
-      .then((result) => {
+      .request('Patient?_sort=identifier&_count=12', { flat: true })
+      .then(result => {
         this.setState({
           patientList: result
         });
@@ -338,14 +338,11 @@ export default class RequestBox extends Component {
       url: this.props.smartAppUrl
     };
 
-    retrieveLaunchContext(
-      link,
-        this.state.patient.id, this.props.client.state
-    ).then((result) => {
-        link = result;
-        console.log(link);
-        // launch the application in a new window
-        window.open(link.url, '_blank');
+    retrieveLaunchContext(link, this.state.patient.id, this.props.client.state).then(result => {
+      link = result;
+      console.log(link);
+      // launch the application in a new window
+      window.open(link.url, '_blank');
     });
   };
 
@@ -401,13 +398,12 @@ export default class RequestBox extends Component {
 
     let linkCopy = Object.assign({}, link);
 
-    return retrieveLaunchContext(
-      linkCopy,
-        this.state.patient.id, this.props.client.state
-    ).then((result) => {
+    return retrieveLaunchContext(linkCopy, this.state.patient.id, this.props.client.state).then(
+      result => {
         linkCopy = result;
         return linkCopy;
-    });
+      }
+    );
   }
 
   /**
@@ -458,7 +454,7 @@ export default class RequestBox extends Component {
   }
 
   render() {
-    const disableSendToCRD = this.isOrderNotSelected() || this.props.loading ;
+    const disableSendToCRD = this.isOrderNotSelected() || this.props.loading;
     const disableLaunchDTR = !this.state.response.questionnaire;
     const disableSendRx = this.isOrderNotSelected() || this.props.loading;
     const disableLaunchSmartOnFhir = this.isPatientNotSelected();
@@ -469,32 +465,30 @@ export default class RequestBox extends Component {
             open={this.state.openPatient}
             onClose={this.exitSmart}
             aria-labelledby="modal-modal-title"
-            aria-describedby="modal-modal-description">
-              <Box sx={style}>
-                    {this.state.patientList instanceof Error
-                      ? this.renderError()
-                      : this.state.patientList.map((patient) => {
-                          return (
-                            <PatientBox
-                              key={patient.id}
-                              patient={patient}
-                              client={this.props.client}
-                              callback={this.updateStateElement}
-                              callbackList={this.updateStateList}
-                              callbackMap={this.updateStateMap}
-                              updatePrefetchCallback={
-                                PrefetchTemplate.generateQueries
-                              }
-                              clearCallback={this.clearState}
-                              ehrUrl={this.props.ehrUrl}
-                              options={this.state.codeValues}
-                              responseExpirationDays={this.props.responseExpirationDays}
-                              defaultUser={this.props.defaultUser}
-                            />
-                          );
-                        })}
-              </Box>
-
+            aria-describedby="modal-modal-description"
+          >
+            <Box sx={style}>
+              {this.state.patientList instanceof Error
+                ? this.renderError()
+                : this.state.patientList.map(patient => {
+                    return (
+                      <PatientBox
+                        key={patient.id}
+                        patient={patient}
+                        client={this.props.client}
+                        callback={this.updateStateElement}
+                        callbackList={this.updateStateList}
+                        callbackMap={this.updateStateMap}
+                        updatePrefetchCallback={PrefetchTemplate.generateQueries}
+                        clearCallback={this.clearState}
+                        ehrUrl={this.props.ehrUrl}
+                        options={this.state.codeValues}
+                        responseExpirationDays={this.props.responseExpirationDays}
+                        defaultUser={this.props.defaultUser}
+                      />
+                    );
+                  })}
+            </Box>
           </Modal>
           <div>
             <Button variant="contained" onClick={this.getPatients} startIcon={<PersonIcon />}>

--- a/src/components/RequestBox/RequestBox.js
+++ b/src/components/RequestBox/RequestBox.js
@@ -156,7 +156,6 @@ export default class RequestBox extends Component {
 
   getPatients = () => {
     this.setState({ openPatient: true });
-
     this.props.client
       .request('Patient?_sort=identifier&_count=12', { flat: true })
       .then(result => {
@@ -317,7 +316,7 @@ export default class RequestBox extends Component {
   }
 
   renderError() {
-    return <span className="patient-error">{this.state.patientList.message}</span>;
+    return <span className="patient-error">Encountered Error: Try Refreshing The Client <br /> {this.state.patientList.message} </span>;
   }
 
   launchSmartOnFhirApp = () => {

--- a/src/components/SMARTBox/PatientBox.js
+++ b/src/components/SMARTBox/PatientBox.js
@@ -47,12 +47,14 @@ export default class PatientBox extends Component {
 
   getCoding(request) {
     let code = null;
-    if (request.resourceType === "DeviceRequest") {
+    if (request.resourceType === 'DeviceRequest') {
       code = request?.codeCodeableConcept.coding[0];
-    } else if (request.resourceType === "ServiceRequest") {
+    } else if (request.resourceType === 'ServiceRequest') {
       code = request?.code?.coding[0];
-    } else if (request.resourceType === "MedicationRequest"
-      || request.resourceType === "MedicationDispense") {
+    } else if (
+      request.resourceType === 'MedicationRequest' ||
+      request.resourceType === 'MedicationDispense'
+    ) {
       code = request?.medicationCodeableConcept?.coding[0];
     }
     if (code) {
@@ -67,10 +69,10 @@ export default class PatientBox extends Component {
       }
     } else {
       code = {
-        code: "Unknown",
-        display: "Unknown",
-        system: "Unknown"
-      }
+        code: 'Unknown',
+        display: 'Unknown',
+        system: 'Unknown'
+      };
     }
     return code;
   }
@@ -146,12 +148,17 @@ export default class PatientBox extends Component {
     this.props.callback('prefetchCompleted', false);
     queries.forEach((query, queryKey) => {
       const urlQuery = '/' + query;
-      requests.push(this.props.client.request(urlQuery).then((response) => {
-        console.log(response);
-        return response;
-      }).then((resource) => {
-        this.props.callbackMap("prefetchedResources", queryKey, resource);
-      }));
+      requests.push(
+        this.props.client
+          .request(urlQuery)
+          .then(response => {
+            console.log(response);
+            return response;
+          })
+          .then(resource => {
+            this.props.callbackMap('prefetchedResources', queryKey, resource);
+          })
+      );
     });
 
     Promise.all(requests)

--- a/src/containers/Index.jsx
+++ b/src/containers/Index.jsx
@@ -3,21 +3,16 @@ import FHIR from 'fhirclient';
 import env from 'env-var';
 import RequestBuilder from '../containers/RequestBuilder';
 
-const Index = (props) => {
-    const [client, setClient] = useState(null);
+const Index = props => {
+  const [client, setClient] = useState(null);
 
-    useEffect(() => {
-        FHIR.oauth2.ready()
-        .then(client => {
-            setClient(client)
-        })
-      }, []);
+  useEffect(() => {
+    FHIR.oauth2.ready().then(client => {
+      setClient(client);
+    });
+  }, []);
 
-    return (
-        <div>
-            {client ? <RequestBuilder client = {client}/> : "Getting Client"}
-        </div>
-    );
+  return <div>{client ? <RequestBuilder client={client} /> : 'Getting Client'}</div>;
 };
 
 export default Index;

--- a/src/containers/Index.jsx
+++ b/src/containers/Index.jsx
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from 'react';
+import FHIR from 'fhirclient';
+import env from 'env-var';
+import RequestBuilder from '../containers/RequestBuilder';
+
+const Index = (props) => {
+    const [client, setClient] = useState(null);
+
+    useEffect(() => {
+        FHIR.oauth2.ready()
+        .then(client => {
+            setClient(client)
+        })
+      }, []);
+
+    return (
+        <div>
+            {client ? <RequestBuilder client = {client}/> : "Getting Client"}
+        </div>
+    );
+};
+
+export default Index;

--- a/src/containers/Launch.jsx
+++ b/src/containers/Launch.jsx
@@ -3,21 +3,15 @@ import FHIR from 'fhirclient';
 import env from 'env-var';
 
 const Launch = () => {
+  useEffect(() => {
+    FHIR.oauth2.authorize({
+      clientId: env.get('REACT_APP_CLIENT').asString(),
+      scope: env.get('REACT_APP_CLIENT_SCOPES').asString(),
+      redirectUri: '/index'
+    });
+  }, []);
 
-    useEffect(() => {
-        FHIR.oauth2
-            .authorize({
-                clientId: env.get('REACT_APP_CLIENT').asString(),
-                scope: env.get('REACT_APP_CLIENT_SCOPES').asString(),
-                redirectUri: '/index'
-            });
-      }, []);
-
-    return (
-        <div>
-            Launching
-        </div>
-    );
+  return <div>Launching</div>;
 };
 
 export default memo(Launch);

--- a/src/containers/Launch.jsx
+++ b/src/containers/Launch.jsx
@@ -1,0 +1,23 @@
+import React, { memo, useState, useEffect } from 'react';
+import FHIR from 'fhirclient';
+import env from 'env-var';
+
+const Launch = () => {
+
+    useEffect(() => {
+        FHIR.oauth2
+            .authorize({
+                clientId: env.get('REACT_APP_CLIENT').asString(),
+                scope: env.get('REACT_APP_CLIENT_SCOPES').asString(),
+                redirectUri: '/index'
+            });
+      }, []);
+
+    return (
+        <div>
+            Launching
+        </div>
+    );
+};
+
+export default memo(Launch);

--- a/src/containers/Launch.jsx
+++ b/src/containers/Launch.jsx
@@ -2,12 +2,12 @@ import React, { memo, useState, useEffect } from 'react';
 import FHIR from 'fhirclient';
 import env from 'env-var';
 
-const Launch = () => {
+const Launch = (props) => {
   useEffect(() => {
     FHIR.oauth2.authorize({
       clientId: env.get('REACT_APP_CLIENT').asString(),
       scope: env.get('REACT_APP_CLIENT_SCOPES').asString(),
-      redirectUri: '/index'
+      redirectUri: props.redirect
     });
   }, []);
 

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -13,211 +13,236 @@ import env from 'env-var';
 import FHIR from 'fhirclient';
 
 export default class RequestBuilder extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            keypair: null,
-            loading: false,
-            logs: [],
-            patient: {},
-            response: null,
-            showSettings: false,
-            token: null,
-            client: this.props.client,
-            // Configurable values
-            alternativeTherapy: env.get('REACT_APP_ALT_DRUG').asBool(),
-            baseUrl: env.get('REACT_APP_EHR_BASE').asString(),
-            cdsUrl: env.get('REACT_APP_CDS_SERVICE').asString(),
-            defaultUser: env.get('REACT_APP_DEFAULT_USER').asString(),
-            ehrUrl: env.get('REACT_APP_EHR_SERVER').asString(),
-            includeConfig: true,
-            launchUrl: env.get('REACT_APP_LAUNCH_URL').asString(),
-            orderSelect: env.get('REACT_APP_ORDER_SELECT').asString(),
-            orderSign: env.get('REACT_APP_ORDER_SIGN').asString(),
-            patientView: env.get('REACT_APP_PATIENT_VIEW').asString(),
-            pimsUrl: env.get('REACT_APP_PIMS_SERVER').asString(),
-            responseExpirationDays: env.get('REACT_APP_RESPONSE_EXPIRATION_DAYS').asInt(),
-            sendPrefetch: true,
-            smartAppUrl: env.get('REACT_APP_SMART_LAUNCH_URL').asString(),
-        };
+  constructor(props) {
+    super(props);
+    this.state = {
+      keypair: null,
+      loading: false,
+      logs: [],
+      patient: {},
+      response: null,
+      showSettings: false,
+      token: null,
+      client: this.props.client,
+      // Configurable values
+      alternativeTherapy: env.get('REACT_APP_ALT_DRUG').asBool(),
+      baseUrl: env.get('REACT_APP_EHR_BASE').asString(),
+      cdsUrl: env.get('REACT_APP_CDS_SERVICE').asString(),
+      defaultUser: env.get('REACT_APP_DEFAULT_USER').asString(),
+      ehrUrl: env.get('REACT_APP_EHR_SERVER').asString(),
+      includeConfig: true,
+      launchUrl: env.get('REACT_APP_LAUNCH_URL').asString(),
+      orderSelect: env.get('REACT_APP_ORDER_SELECT').asString(),
+      orderSign: env.get('REACT_APP_ORDER_SIGN').asString(),
+      patientView: env.get('REACT_APP_PATIENT_VIEW').asString(),
+      pimsUrl: env.get('REACT_APP_PIMS_SERVER').asString(),
+      responseExpirationDays: env.get('REACT_APP_RESPONSE_EXPIRATION_DAYS').asInt(),
+      sendPrefetch: true,
+      smartAppUrl: env.get('REACT_APP_SMART_LAUNCH_URL').asString()
+    };
 
-        this.updateStateElement = this.updateStateElement.bind(this);
-        this.submit_info = this.submit_info.bind(this);
-        this.consoleLog = this.consoleLog.bind(this);
-        this.takeSuggestion = this.takeSuggestion.bind(this);
-        this.reconnectEhr = this.reconnectEhr.bind(this);
-        this.requestBox = React.createRef();
+    this.updateStateElement = this.updateStateElement.bind(this);
+    this.submit_info = this.submit_info.bind(this);
+    this.consoleLog = this.consoleLog.bind(this);
+    this.takeSuggestion = this.takeSuggestion.bind(this);
+    this.reconnectEhr = this.reconnectEhr.bind(this);
+    this.requestBox = React.createRef();
+  }
+
+  componentDidMount() {
+    const callback = keypair => {
+      this.setState({ keypair });
+    };
+
+    setupKeys(callback);
+    if (!this.state.client) {
+      this.reconnectEhr();
     }
+  }
 
-    componentDidMount() {
-        const callback = (keypair) => {
-            this.setState({ keypair });
-        }
+  reconnectEhr() {
+    console.log(this.state.baseUrl);
+    FHIR.oauth2
+      .authorize({
+        clientId: env.get('REACT_APP_CLIENT').asString(),
+        iss: this.state.baseUrl,
+        redirectUri: '/index',
+        scope: env.get('REACT_APP_CLIENT_SCOPES').asString()
+      })
+      .then(client => {
+        this.setState({ client: client });
+      });
+  }
 
-        setupKeys(callback);
-        if(!this.state.client) {
-            this.reconnectEhr()
-        }
+  consoleLog(content, type) {
+    console.log(content);
+    let jsonContent = {
+      content: content,
+      type: type
+    };
+    this.setState(prevState => ({
+      logs: [...prevState.logs, jsonContent]
+    }));
+  }
 
+  updateStateElement = (elementName, text) => {
+    this.setState({ [elementName]: text });
+  };
+
+  timeout = time => {
+    let controller = new AbortController();
+    setTimeout(() => controller.abort(), time * 1000);
+    return controller;
+  };
+
+  submit_info(prefetch, request, patient, hook) {
+    this.setState({ loading: true });
+    this.consoleLog('Initiating form submission', types.info);
+    this.setState({ patient });
+    const hookConfig = {
+      includeConfig: this.state.includeConfig,
+      alternativeTherapy: this.state.alternativeTherapy
+    };
+    let user = this.state.defaultUser;
+    let json_request = buildRequest(
+      request,
+      user,
+      patient,
+      this.state.ehrUrl,
+      this.state.client.state.tokenResponse,
+      prefetch,
+      this.state.sendPrefetch,
+      hook,
+      hookConfig
+    );
+    let cdsUrl = this.state.cdsUrl;
+    if (hook === 'order-sign') {
+      cdsUrl = cdsUrl + '/' + this.state.orderSign;
+    } else if (hook === 'order-select') {
+      cdsUrl = cdsUrl + '/' + this.state.orderSelect;
+    } else if (hook === 'patient-view') {
+      cdsUrl = cdsUrl + '/' + this.state.patientView;
+    } else {
+      this.consoleLog("ERROR: unknown hook type: '", hook, "'");
+      return;
     }
-
-    reconnectEhr() {
-        console.log(this.state.baseUrl);
-        FHIR.oauth2.authorize({
-            clientId: env.get('REACT_APP_CLIENT').asString(),
-            iss: this.state.baseUrl,
-            redirectUri: '/index',
-            scope: env.get('REACT_APP_CLIENT_SCOPES').asString()
-        }).then((client) => {
-            this.setState({client: client})
-        })
-    }
-
-    consoleLog(content, type) {
-        console.log(content);
-        let jsonContent = {
-            content: content,
-            type: type
-        }
-        this.setState(prevState => ({
-            logs: [...prevState.logs, jsonContent]
-        }))
-    }
-
-    updateStateElement = (elementName, text) => {
-        this.setState({ [elementName]: text });
-    }
-
-    timeout = (time) => {
-        let controller = new AbortController();
-        setTimeout(()=>controller.abort(), time * 1000);
-        return controller;
-    }
-
-    submit_info(prefetch, request, patient, hook) {
-        this.setState({loading: true});
-        this.consoleLog("Initiating form submission", types.info);
-        this.setState({patient});
-        const hookConfig = {
-            "includeConfig": this.state.includeConfig,
-            "alternativeTherapy": this.state.alternativeTherapy
-        }
-        let user = this.state.defaultUser;
-        let json_request = buildRequest(request, user, patient, this.state.ehrUrl, this.state.client.state.tokenResponse, prefetch, this.state.sendPrefetch, hook, hookConfig);
-        let cdsUrl = this.state.cdsUrl;
-        if (hook === "order-sign") {
-            cdsUrl = cdsUrl + "/" + this.state.orderSign;
-        } else if (hook === "order-select") {
-            cdsUrl = cdsUrl + "/" + this.state.orderSelect;
-        } else if (hook === "patient-view") {
-            cdsUrl = cdsUrl + "/" + this.state.patientView;
-        } else {
-            this.consoleLog("ERROR: unknown hook type: '", hook, "'");
-            return;
-        }
-        let baseUrl = this.state.baseUrl;
-        const jwt = "Bearer " + createJwt(this.state.keypair, baseUrl, cdsUrl);
-        const headers = new Headers({
-            "Content-Type": "application/json",
-            "authorization": jwt
-        });
-        try {
-            fetch(cdsUrl, {
-                method: "POST",
-                headers: headers,
-                body: JSON.stringify(json_request),
-                signal: this.timeout(10).signal //Timeout set to 10 seconds
-            }).then(response => {
-                clearTimeout(this.timeout)
-                response.json().then((fhirResponse) => {
-                    console.log(fhirResponse);
-                    if (fhirResponse?.status) {
-                        this.consoleLog("Server returned status "
-                            + fhirResponse.status + ": "
-                            + fhirResponse.error, types.error);
-                        this.consoleLog(fhirResponse.message, types.error);
-                    } else {
-                        this.setState({ response: fhirResponse });
-                    }
-                    this.setState({ loading: false });
-                })
-            }).catch(() => {
-                this.consoleLog("No response received from the server", types.error);
-                this.setState({ response: null });
-                this.setState({loading: false});
-            });
-        } catch (error) {
-            this.setState({ loading: false });
-            this.consoleLog("Unexpected error occurred", types.error)
-            if (error instanceof TypeError) {
-                this.consoleLog(error.name + ": " + error.message, types.error);
+    let baseUrl = this.state.baseUrl;
+    const jwt = 'Bearer ' + createJwt(this.state.keypair, baseUrl, cdsUrl);
+    const headers = new Headers({
+      'Content-Type': 'application/json',
+      authorization: jwt
+    });
+    try {
+      fetch(cdsUrl, {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(json_request),
+        signal: this.timeout(10).signal //Timeout set to 10 seconds
+      })
+        .then(response => {
+          clearTimeout(this.timeout);
+          response.json().then(fhirResponse => {
+            console.log(fhirResponse);
+            if (fhirResponse?.status) {
+              this.consoleLog(
+                'Server returned status ' + fhirResponse.status + ': ' + fhirResponse.error,
+                types.error
+              );
+              this.consoleLog(fhirResponse.message, types.error);
+            } else {
+              this.setState({ response: fhirResponse });
             }
             this.setState({ loading: false });
-        };
+          });
+        })
+        .catch(() => {
+          this.consoleLog('No response received from the server', types.error);
+          this.setState({ response: null });
+          this.setState({ loading: false });
+        });
+    } catch (error) {
+      this.setState({ loading: false });
+      this.consoleLog('Unexpected error occurred', types.error);
+      if (error instanceof TypeError) {
+        this.consoleLog(error.name + ': ' + error.message, types.error);
+      }
+      this.setState({ loading: false });
     }
+  }
 
   takeSuggestion(resource) {
     // when a suggestion is taken, call into the requestBox to resubmit the CRD request with the new request
     this.requestBox.current.replaceRequestAndSubmit(resource);
   }
 
-    render() {
-        return (
-            <div>
-                <div className="nav-header">
-                    <button className={"btn btn-class settings " + (this.state.showSettings ? "active" : "not-active")} onClick={() => this.updateStateElement("showSettings", !this.state.showSettings)}><span className="glyphicon glyphicon-cog settings-icon" /></button>
-                    <button className="btn btn-class" onClick={() => {this.reconnectEhr()}}>Reconnect EHR</button>
-                </div>
-                <div className="form-group container left-form">
-                    <div id="settings-header">
+  render() {
+    return (
+      <div>
+        <div className="nav-header">
+          <button
+            className={
+              'btn btn-class settings ' + (this.state.showSettings ? 'active' : 'not-active')
+            }
+            onClick={() => this.updateStateElement('showSettings', !this.state.showSettings)}
+          >
+            <span className="glyphicon glyphicon-cog settings-icon" />
+          </button>
+          <button
+            className="btn btn-class"
+            onClick={() => {
+              this.reconnectEhr();
+            }}
+          >
+            Reconnect EHR
+          </button>
+        </div>
+        <div className="form-group container left-form">
+          <div id="settings-header"></div>
+          {this.state.showSettings && (
+            <SettingsBox
+              state={this.state}
+              consoleLog={this.consoleLog}
+              updateCB={this.updateStateElement}
+            />
+          )}
+          <div>
+            {/*for the ehr launch */}
+            <RequestBox
+              ehrUrl={this.state.ehrUrl}
+              submitInfo={this.submit_info}
+              access_token={this.state.token}
+              client={this.state.client}
+              fhirServerUrl={this.state.baseUrl}
+              fhirVersion={'r4'}
+              patientId={this.state.patient.id}
+              launchUrl={this.state.launchUrl}
+              responseExpirationDays={this.state.responseExpirationDays}
+              pimsUrl={this.state.pimsUrl}
+              smartAppUrl={this.state.smartAppUrl}
+              defaultUser={this.state.defaultUser}
+              ref={this.requestBox}
+              loading={this.state.loading}
+              consoleLog={this.consoleLog}
+            />
+          </div>
+          <br />
 
+          <br />
+          <br />
+          <br />
+          <ConsoleBox logs={this.state.logs} />
+        </div>
 
-                    </div>
-                    {this.state.showSettings &&
-                        <SettingsBox
-                            state={this.state}
-                            consoleLog={this.consoleLog}
-                            updateCB={this.updateStateElement}
-                        />}
-                    <div>
-                        {/*for the ehr launch */}
-                        <RequestBox
-                            ehrUrl={this.state.ehrUrl}
-                            submitInfo={this.submit_info}
-                            access_token={this.state.token}
-                            client={this.state.client}
-                            fhirServerUrl={this.state.baseUrl}
-                            fhirVersion={'r4'}
-                            patientId={this.state.patient.id}
-                            launchUrl={this.state.launchUrl}
-                            responseExpirationDays={this.state.responseExpirationDays}
-                            pimsUrl={this.state.pimsUrl}
-                            smartAppUrl={this.state.smartAppUrl}
-                            defaultUser={this.state.defaultUser}
-                            ref={this.requestBox}
-                            loading={this.state.loading}
-                            consoleLog={this.consoleLog}
-                        />
-
-                    </div>
-                    <br />
-
-                    <br />
-                    <br />
-                    <br />
-                    <ConsoleBox logs={this.state.logs} />
-                </div>
-
-                <div className="right-form">
-                    <DisplayBox
-                        response={this.state.response}
-                        client={this.state.client}
-                        patientId={this.state.patient.id}
-                        ehrLaunch={true}
-                        takeSuggestion={this.takeSuggestion} />
-                </div>
-
-            </div>
-        )
-    }
+        <div className="right-form">
+          <DisplayBox
+            response={this.state.response}
+            client={this.state.client}
+            patientId={this.state.patient.id}
+            ehrLaunch={true}
+            takeSuggestion={this.takeSuggestion}
+          />
+        </div>
+      </div>
+    );
+  }
 }

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -68,11 +68,8 @@ export default class RequestBuilder extends Component {
       .authorize({
         clientId: env.get('REACT_APP_CLIENT').asString(),
         iss: this.state.baseUrl,
-        redirectUri: '/index',
+        redirectUri: this.props.redirect,
         scope: env.get('REACT_APP_CLIENT_SCOPES').asString()
-      })
-      .then(client => {
-        this.setState({ client: client });
       });
   }
 

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -10,224 +10,214 @@ import buildRequest from '../util/buildRequest.js';
 import { types } from '../util/data.js';
 import { createJwt, login, setupKeys } from '../util/auth';
 import env from 'env-var';
+import FHIR from 'fhirclient';
 
 export default class RequestBuilder extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      keypair: null,
-      loading: false,
-      logs: [],
-      patient: {},
-      response: null,
-      showSettings: false,
-      token: null,
-      // Configurable values
-      alternativeTherapy: env.get('REACT_APP_ALT_DRUG').asBool(),
-      baseUrl: env.get('REACT_APP_EHR_BASE').asString(),
-      cdsUrl: env.get('REACT_APP_CDS_SERVICE').asString(),
-      defaultUser: env.get('REACT_APP_DEFAULT_USER').asString(),
-      ehrUrl: env.get('REACT_APP_EHR_SERVER').asString(),
-      includeConfig: true,
-      launchUrl: env.get('REACT_APP_LAUNCH_URL').asString(),
-      orderSelect: env.get('REACT_APP_ORDER_SELECT').asString(),
-      orderSign: env.get('REACT_APP_ORDER_SIGN').asString(),
-      patientView: env.get('REACT_APP_PATIENT_VIEW').asString(),
-      pimsUrl: env.get('REACT_APP_PIMS_SERVER').asString(),
-      responseExpirationDays: env.get('REACT_APP_RESPONSE_EXPIRATION_DAYS').asInt(),
-      sendPrefetch: true,
-      smartAppUrl: env.get('REACT_APP_SMART_LAUNCH_URL').asString()
-    };
+    constructor(props) {
+        super(props);
+        this.state = {
+            keypair: null,
+            loading: false,
+            logs: [],
+            patient: {},
+            response: null,
+            showSettings: false,
+            token: null,
+            client: this.props.client,
+            // Configurable values
+            alternativeTherapy: env.get('REACT_APP_ALT_DRUG').asBool(),
+            baseUrl: env.get('REACT_APP_EHR_BASE').asString(),
+            cdsUrl: env.get('REACT_APP_CDS_SERVICE').asString(),
+            defaultUser: env.get('REACT_APP_DEFAULT_USER').asString(),
+            ehrUrl: env.get('REACT_APP_EHR_SERVER').asString(),
+            includeConfig: true,
+            launchUrl: env.get('REACT_APP_LAUNCH_URL').asString(),
+            orderSelect: env.get('REACT_APP_ORDER_SELECT').asString(),
+            orderSign: env.get('REACT_APP_ORDER_SIGN').asString(),
+            patientView: env.get('REACT_APP_PATIENT_VIEW').asString(),
+            pimsUrl: env.get('REACT_APP_PIMS_SERVER').asString(),
+            responseExpirationDays: env.get('REACT_APP_RESPONSE_EXPIRATION_DAYS').asInt(),
+            sendPrefetch: true,
+            smartAppUrl: env.get('REACT_APP_SMART_LAUNCH_URL').asString(),
+        };
 
-    this.updateStateElement = this.updateStateElement.bind(this);
-    this.submit_info = this.submit_info.bind(this);
-    this.consoleLog = this.consoleLog.bind(this);
-    this.takeSuggestion = this.takeSuggestion.bind(this);
-    this.requestBox = React.createRef();
-  }
-
-  componentDidMount() {
-    const callback = keypair => {
-      this.setState({ keypair });
-    };
-
-    setupKeys(callback);
-
-    login()
-      .then(response => {
-        return response.json();
-      })
-      .then(token => {
-        this.setState({ token });
-      })
-      .catch(error => {
-        // fails when keycloak isn't running, add dummy token
-        this.setState({ token: { access_token: '' } });
-      });
-  }
-
-  consoleLog(content, type) {
-    console.log(content);
-    let jsonContent = {
-      content: content,
-      type: type
-    };
-    this.setState(prevState => ({
-      logs: [...prevState.logs, jsonContent]
-    }));
-  }
-
-  updateStateElement = (elementName, text) => {
-    this.setState({ [elementName]: text });
-  };
-
-  timeout = time => {
-    let controller = new AbortController();
-    setTimeout(() => controller.abort(), time * 1000);
-    return controller;
-  };
-
-  submit_info(prefetch, request, patient, hook) {
-    this.setState({ loading: true });
-    this.consoleLog('Initiating form submission', types.info);
-    this.setState({ patient });
-    const hookConfig = {
-      includeConfig: this.state.includeConfig,
-      alternativeTherapy: this.state.alternativeTherapy
-    };
-    let user = this.state.defaultUser;
-    let json_request = buildRequest(
-      request,
-      user,
-      patient,
-      this.state.ehrUrl,
-      this.state.token,
-      prefetch,
-      this.state.sendPrefetch,
-      hook,
-      hookConfig
-    );
-    let cdsUrl = this.state.cdsUrl;
-    if (hook === 'order-sign') {
-      cdsUrl = cdsUrl + '/' + this.state.orderSign;
-    } else if (hook === 'order-select') {
-      cdsUrl = cdsUrl + '/' + this.state.orderSelect;
-    } else if (hook === 'patient-view') {
-      cdsUrl = cdsUrl + '/' + this.state.patientView;
-    } else {
-      this.consoleLog("ERROR: unknown hook type: '", hook, "'");
-      return;
+        this.updateStateElement = this.updateStateElement.bind(this);
+        this.submit_info = this.submit_info.bind(this);
+        this.consoleLog = this.consoleLog.bind(this);
+        this.takeSuggestion = this.takeSuggestion.bind(this);
+        this.reconnectEhr = this.reconnectEhr.bind(this);
+        this.requestBox = React.createRef();
     }
-    let baseUrl = this.state.baseUrl;
-    const jwt = 'Bearer ' + createJwt(this.state.keypair, baseUrl, cdsUrl);
-    const headers = new Headers({
-      'Content-Type': 'application/json',
-      authorization: jwt
-    });
-    try {
-      fetch(cdsUrl, {
-        method: 'POST',
-        headers: headers,
-        body: JSON.stringify(json_request),
-        signal: this.timeout(10).signal //Timeout set to 10 seconds
-      })
-        .then(response => {
-          clearTimeout(this.timeout);
-          response.json().then(fhirResponse => {
-            console.log(fhirResponse);
-            if (fhirResponse?.status) {
-              this.consoleLog(
-                'Server returned status ' + fhirResponse.status + ': ' + fhirResponse.error,
-                types.error
-              );
-              this.consoleLog(fhirResponse.message, types.error);
-            } else {
-              this.setState({ response: fhirResponse });
+
+    componentDidMount() {
+        const callback = (keypair) => {
+            this.setState({ keypair });
+        }
+
+        setupKeys(callback);
+        if(!this.state.client) {
+            this.reconnectEhr()
+        }
+
+    }
+
+    reconnectEhr() {
+        console.log(this.state.baseUrl);
+        FHIR.oauth2.authorize({
+            clientId: env.get('REACT_APP_CLIENT').asString(),
+            iss: this.state.baseUrl,
+            redirectUri: '/index',
+            scope: env.get('REACT_APP_CLIENT_SCOPES').asString()
+        }).then((client) => {
+            this.setState({client: client})
+        })
+    }
+
+    consoleLog(content, type) {
+        console.log(content);
+        let jsonContent = {
+            content: content,
+            type: type
+        }
+        this.setState(prevState => ({
+            logs: [...prevState.logs, jsonContent]
+        }))
+    }
+
+    updateStateElement = (elementName, text) => {
+        this.setState({ [elementName]: text });
+    }
+
+    timeout = (time) => {
+        let controller = new AbortController();
+        setTimeout(()=>controller.abort(), time * 1000);
+        return controller;
+    }
+
+    submit_info(prefetch, request, patient, hook) {
+        this.setState({loading: true});
+        this.consoleLog("Initiating form submission", types.info);
+        this.setState({patient});
+        const hookConfig = {
+            "includeConfig": this.state.includeConfig,
+            "alternativeTherapy": this.state.alternativeTherapy
+        }
+        let user = this.state.defaultUser;
+        let json_request = buildRequest(request, user, patient, this.state.ehrUrl, this.state.client.state.tokenResponse, prefetch, this.state.sendPrefetch, hook, hookConfig);
+        let cdsUrl = this.state.cdsUrl;
+        if (hook === "order-sign") {
+            cdsUrl = cdsUrl + "/" + this.state.orderSign;
+        } else if (hook === "order-select") {
+            cdsUrl = cdsUrl + "/" + this.state.orderSelect;
+        } else if (hook === "patient-view") {
+            cdsUrl = cdsUrl + "/" + this.state.patientView;
+        } else {
+            this.consoleLog("ERROR: unknown hook type: '", hook, "'");
+            return;
+        }
+        let baseUrl = this.state.baseUrl;
+        const jwt = "Bearer " + createJwt(this.state.keypair, baseUrl, cdsUrl);
+        const headers = new Headers({
+            "Content-Type": "application/json",
+            "authorization": jwt
+        });
+        try {
+            fetch(cdsUrl, {
+                method: "POST",
+                headers: headers,
+                body: JSON.stringify(json_request),
+                signal: this.timeout(10).signal //Timeout set to 10 seconds
+            }).then(response => {
+                clearTimeout(this.timeout)
+                response.json().then((fhirResponse) => {
+                    console.log(fhirResponse);
+                    if (fhirResponse?.status) {
+                        this.consoleLog("Server returned status "
+                            + fhirResponse.status + ": "
+                            + fhirResponse.error, types.error);
+                        this.consoleLog(fhirResponse.message, types.error);
+                    } else {
+                        this.setState({ response: fhirResponse });
+                    }
+                    this.setState({ loading: false });
+                })
+            }).catch(() => {
+                this.consoleLog("No response received from the server", types.error);
+                this.setState({ response: null });
+                this.setState({loading: false});
+            });
+        } catch (error) {
+            this.setState({ loading: false });
+            this.consoleLog("Unexpected error occurred", types.error)
+            if (error instanceof TypeError) {
+                this.consoleLog(error.name + ": " + error.message, types.error);
             }
             this.setState({ loading: false });
-          });
-        })
-        .catch(() => {
-          this.consoleLog('No response received from the server', types.error);
-          this.setState({ response: null });
-          this.setState({ loading: false });
-        });
-    } catch (error) {
-      this.setState({ loading: false });
-      this.consoleLog('Unexpected error occurred', types.error);
-      if (error instanceof TypeError) {
-        this.consoleLog(error.name + ': ' + error.message, types.error);
-      }
+        };
     }
-  }
 
   takeSuggestion(resource) {
     // when a suggestion is taken, call into the requestBox to resubmit the CRD request with the new request
     this.requestBox.current.replaceRequestAndSubmit(resource);
   }
 
-  render() {
-    return (
-      <div>
-        <div className="nav-header">
-          <button
-            className={
-              'btn btn-class settings ' + (this.state.showSettings ? 'active' : 'not-active')
-            }
-            onClick={() => this.updateStateElement('showSettings', !this.state.showSettings)}
-          >
-            <span className="glyphicon glyphicon-cog settings-icon" />
-          </button>
-        </div>
-        <div className="form-group container left-form">
-          <div id="settings-header"></div>
-          {this.state.showSettings && (
-            <SettingsBox
-              state={this.state}
-              consoleLog={this.consoleLog}
-              updateCB={this.updateStateElement}
-            />
-          )}
-          <div>
-            {/*for the ehr launch */}
-            <RequestBox
-              ehrUrl={this.state.ehrUrl}
-              submitInfo={this.submit_info}
-              access_token={this.state.token}
-              fhirServerUrl={this.state.baseUrl}
-              fhirVersion={'r4'}
-              patientId={this.state.patient.id}
-              launchUrl={this.state.launchUrl}
-              responseExpirationDays={this.state.responseExpirationDays}
-              pimsUrl={this.state.pimsUrl}
-              smartAppUrl={this.state.smartAppUrl}
-              defaultUser={this.state.defaultUser}
-              ref={this.requestBox}
-              loading={this.state.loading}
-              consoleLog={this.consoleLog}
-            />
-          </div>
-          <br />
+    render() {
+        return (
+            <div>
+                <div className="nav-header">
+                    <button className={"btn btn-class settings " + (this.state.showSettings ? "active" : "not-active")} onClick={() => this.updateStateElement("showSettings", !this.state.showSettings)}><span className="glyphicon glyphicon-cog settings-icon" /></button>
+                    <button className="btn btn-class" onClick={() => {this.reconnectEhr()}}>Reconnect EHR</button>
+                </div>
+                <div className="form-group container left-form">
+                    <div id="settings-header">
 
-          <br />
-          <br />
-          <br />
-          <ConsoleBox logs={this.state.logs} />
-        </div>
 
-        <div className="right-form">
-          <DisplayBox
-            response={this.state.response}
-            patientId={this.state.patient.id}
-            ehrLaunch={true}
-            fhirServerUrl={this.state.baseUrl}
-            fhirVersion={'r4'}
-            ehrUrl={this.state.ehrUrl}
-            access_token={this.state.token}
-            takeSuggestion={this.takeSuggestion}
-          />
-        </div>
-      </div>
-    );
-  }
+                    </div>
+                    {this.state.showSettings &&
+                        <SettingsBox
+                            state={this.state}
+                            consoleLog={this.consoleLog}
+                            updateCB={this.updateStateElement}
+                        />}
+                    <div>
+                        {/*for the ehr launch */}
+                        <RequestBox
+                            ehrUrl={this.state.ehrUrl}
+                            submitInfo={this.submit_info}
+                            access_token={this.state.token}
+                            client={this.state.client}
+                            fhirServerUrl={this.state.baseUrl}
+                            fhirVersion={'r4'}
+                            patientId={this.state.patient.id}
+                            launchUrl={this.state.launchUrl}
+                            responseExpirationDays={this.state.responseExpirationDays}
+                            pimsUrl={this.state.pimsUrl}
+                            smartAppUrl={this.state.smartAppUrl}
+                            defaultUser={this.state.defaultUser}
+                            ref={this.requestBox}
+                            loading={this.state.loading}
+                            consoleLog={this.consoleLog}
+                        />
+
+                    </div>
+                    <br />
+
+                    <br />
+                    <br />
+                    <br />
+                    <ConsoleBox logs={this.state.logs} />
+                </div>
+
+                <div className="right-form">
+                    <DisplayBox
+                        response={this.state.response}
+                        client={this.state.client}
+                        patientId={this.state.patient.id}
+                        ehrLaunch={true}
+                        takeSuggestion={this.takeSuggestion} />
+                </div>
+
+            </div>
+        )
+    }
 }

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -57,11 +57,13 @@ export default class RequestBuilder extends Component {
     setupKeys(callback);
     if (!this.state.client) {
       this.reconnectEhr();
+    } else {
+      this.setState({ baseUrl: this.state.client.state.serverUrl });
+      this.setState({ ehrUrl: this.state.client.state.serverUrl });
     }
   }
 
   reconnectEhr() {
-    console.log(this.state.baseUrl);
     FHIR.oauth2
       .authorize({
         clientId: env.get('REACT_APP_CLIENT').asString(),

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -11,42 +11,43 @@ import axios from 'axios';
  * @param {*} fhirBaseUrl - The base URL of the FHIR server in context
  */
 function retrieveLaunchContext(link, patientId, clientState) {
-    return new Promise((resolve, reject) => {
-        const headers = clientState.tokenResponse ?
-        {
-        "Accept": 'application/json',
-        "Authorization": `Bearer ${clientState.tokenResponse.access_token}`
+  return new Promise((resolve, reject) => {
+    const headers = clientState.tokenResponse
+      ? {
+          Accept: 'application/json',
+          Authorization: `Bearer ${clientState.tokenResponse.access_token}`
         }
       : {
           Accept: 'application/json'
         };
-        const launchParameters = {
-        patient: patientId,
-        };
-    
-        if (link.appContext) {
-        launchParameters.appContext = link.appContext;
-        }
-    
-        // May change when the launch context creation endpoint becomes a standard endpoint for all EHR providers
-        axios({
-        method: 'post',
-        url: `${clientState.serverUrl}/_services/smart/Launch`,
-        headers,
-        data: {
-            launchUrl: link.url,
-            parameters: launchParameters,
-        },
-        }).then((result) => {
+    const launchParameters = {
+      patient: patientId
+    };
+
+    if (link.appContext) {
+      launchParameters.appContext = link.appContext;
+    }
+
+    // May change when the launch context creation endpoint becomes a standard endpoint for all EHR providers
+    axios({
+      method: 'post',
+      url: `${clientState.serverUrl}/_services/smart/Launch`,
+      headers,
+      data: {
+        launchUrl: link.url,
+        parameters: launchParameters
+      }
+    })
+      .then(result => {
         if (result.data && Object.prototype.hasOwnProperty.call(result.data, 'launch_id')) {
           if (link.url.indexOf('?') < 0) {
             link.url += '?';
           } else {
             link.url += '&';
-            }
-            link.url += `launch=${result.data.launch_id}`;
-            link.url += `&iss=${clientState.serverUrl}`;
-            return resolve(link);
+          }
+          link.url += `launch=${result.data.launch_id}`;
+          link.url += `&iss=${clientState.serverUrl}`;
+          return resolve(link);
         }
         console.error(
           'FHIR server endpoint did not return a launch_id to launch the SMART app. See network calls to the Launch endpoint for more details'

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -10,44 +10,43 @@ import axios from 'axios';
  * @param {*} patientId - The identifier of the patient in context
  * @param {*} fhirBaseUrl - The base URL of the FHIR server in context
  */
-function retrieveLaunchContext(link, accessToken, patientId, fhirBaseUrl, fhirVersion) {
-  return new Promise((resolve, reject) => {
-    const headers = accessToken
-      ? {
-          Accept: 'application/json',
-          Authorization: `Bearer ${accessToken.access_token}`
+function retrieveLaunchContext(link, patientId, clientState) {
+    return new Promise((resolve, reject) => {
+        const headers = clientState.tokenResponse ?
+        {
+        "Accept": 'application/json',
+        "Authorization": `Bearer ${clientState.tokenResponse.access_token}`
         }
       : {
           Accept: 'application/json'
         };
-    const launchParameters = {
-      patient: patientId
-    };
-
-    if (link.appContext) {
-      launchParameters.appContext = link.appContext;
-    }
-
-    // May change when the launch context creation endpoint becomes a standard endpoint for all EHR providers
-    axios({
-      method: 'post',
-      url: `${fhirBaseUrl}/_services/smart/Launch`,
-      headers,
-      data: {
-        launchUrl: link.url,
-        parameters: launchParameters
-      }
-    })
-      .then(result => {
+        const launchParameters = {
+        patient: patientId,
+        };
+    
+        if (link.appContext) {
+        launchParameters.appContext = link.appContext;
+        }
+    
+        // May change when the launch context creation endpoint becomes a standard endpoint for all EHR providers
+        axios({
+        method: 'post',
+        url: `${clientState.serverUrl}/_services/smart/Launch`,
+        headers,
+        data: {
+            launchUrl: link.url,
+            parameters: launchParameters,
+        },
+        }).then((result) => {
         if (result.data && Object.prototype.hasOwnProperty.call(result.data, 'launch_id')) {
           if (link.url.indexOf('?') < 0) {
             link.url += '?';
           } else {
             link.url += '&';
-          }
-          link.url += `launch=${result.data.launch_id}`;
-          link.url += `&iss=${fhirBaseUrl}`;
-          return resolve(link);
+            }
+            link.url += `launch=${result.data.launch_id}`;
+            link.url += `&iss=${clientState.serverUrl}`;
+            return resolve(link);
         }
         console.error(
           'FHIR server endpoint did not return a launch_id to launch the SMART app. See network calls to the Launch endpoint for more details'


### PR DESCRIPTION
## Describe your changes

Makes the request generator a SMART app.  When launching through a launcher or sandbox, use `/launch`, otherwise accessing the page will initiate a standalone launch against whatever EHR is in the env variables.  You can use the reconnect button to connect to a different EHR by changing the setting after loading.  