### PR TITLE
Redirect uri fix

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter , HashRouter , Routes, Route } from 'react-router-dom';
+import { BrowserRouter, HashRouter, Routes, Route } from 'react-router-dom';
 import RequestBuilder from '../containers/RequestBuilder';
 import PatientPortal from '../containers/PatientPortal';
 import theme from '../containers/styles/theme';
@@ -14,18 +14,17 @@ const App = () => {
   return (
     <Router>
       <Routes>
-        <Route path='/launch' element={<Launch redirect={redirect} />} />
-        <Route path='/index' element={<Index />} />
+        <Route path="/launch" element={<Launch redirect={redirect} />} />
+        <Route path="/index" element={<Index />} />
         <Route
-          path='/patient-portal'
+          path="/patient-portal"
           element={
             <ThemeProvider theme={theme}>
               <PatientPortal />
             </ThemeProvider>
           }
         />
-        <Route path="/" exact element={<RequestBuilder redirect = {redirect} />} />
-
+        <Route path="/" exact element={<RequestBuilder redirect={redirect} />} />
       </Routes>
     </Router>
   );

--- a/src/components/RequestBox/RequestBox.js
+++ b/src/components/RequestBox/RequestBox.js
@@ -316,7 +316,11 @@ export default class RequestBox extends Component {
   }
 
   renderError() {
-    return <span className="patient-error">Encountered Error: Try Refreshing The Client <br /> {this.state.patientList.message} </span>;
+    return (
+      <span className="patient-error">
+        Encountered Error: Try Refreshing The Client <br /> {this.state.patientList.message}{' '}
+      </span>
+    );
   }
 
   launchSmartOnFhirApp = () => {

--- a/src/containers/Launch.jsx
+++ b/src/containers/Launch.jsx
@@ -17,7 +17,7 @@ const Launch = (props) => {
     FHIR.oauth2.authorize({
       clientId: env.get('REACT_APP_CLIENT').asString(),
       scope: env.get('REACT_APP_CLIENT_SCOPES').asString(),
-      redirectUri: props.redirect
+      redirectUri: props.redirect,
       iss: iss,
       launch: launch
     });

--- a/src/containers/Launch.jsx
+++ b/src/containers/Launch.jsx
@@ -3,17 +3,17 @@ import FHIR from 'fhirclient';
 import env from 'env-var';
 import queryString from 'querystring';
 
-const Launch = (props) => {
+const Launch = props => {
   useEffect(() => {
-    // this is a workaround for the fhir client not being able to pull values out of the 
+    // this is a workaround for the fhir client not being able to pull values out of the
     // hash. Regex will look for different permutations of a hashrouter url /#/launch /#launch #launch /#launch
     const params = queryString.parse((window.location.hash || '').replace(/\/?#\/?launch\?/, ''));
-   
+
     // if these are null then the client will pull them out of the browsers query string
-    // so we don't need to do that here. 
+    // so we don't need to do that here.
     const iss = params.iss;
     const launch = params.launch;
-    
+
     FHIR.oauth2.authorize({
       clientId: env.get('REACT_APP_CLIENT').asString(),
       scope: env.get('REACT_APP_CLIENT_SCOPES').asString(),

--- a/src/containers/Launch.jsx
+++ b/src/containers/Launch.jsx
@@ -1,13 +1,25 @@
 import React, { memo, useState, useEffect } from 'react';
 import FHIR from 'fhirclient';
 import env from 'env-var';
+import queryString from 'querystring';
 
 const Launch = (props) => {
   useEffect(() => {
+    // this is a workaround for the fhir client not being able to pull values out of the 
+    // hash. Regex will look for different permutations of a hashrouter url /#/launch /#launch #launch /#launch
+    const params = queryString.parse((window.location.hash || '').replace(/\/?#\/?launch\?/, ''));
+   
+    // if these are null then the client will pull them out of the browsers query string
+    // so we don't need to do that here. 
+    const iss = params.iss;
+    const launch = params.launch;
+    
     FHIR.oauth2.authorize({
       clientId: env.get('REACT_APP_CLIENT').asString(),
       scope: env.get('REACT_APP_CLIENT_SCOPES').asString(),
       redirectUri: props.redirect
+      iss: iss,
+      launch: launch
     });
   }, []);
 

--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -64,13 +64,12 @@ export default class RequestBuilder extends Component {
   }
 
   reconnectEhr() {
-    FHIR.oauth2
-      .authorize({
-        clientId: env.get('REACT_APP_CLIENT').asString(),
-        iss: this.state.baseUrl,
-        redirectUri: this.props.redirect,
-        scope: env.get('REACT_APP_CLIENT_SCOPES').asString()
-      });
+    FHIR.oauth2.authorize({
+      clientId: env.get('REACT_APP_CLIENT').asString(),
+      iss: this.state.baseUrl,
+      redirectUri: this.props.redirect,
+      scope: env.get('REACT_APP_CLIENT_SCOPES').asString()
+    });
   }
 
   consoleLog(content, type) {


### PR DESCRIPTION
## Describe your changes

Fixing issue where when using the HashRouter on GH Pages the values for the smart launch iss and launch parameters are not pulled from the url by the fhir client because they are in the hash field and not the query **parameters**

## Issue ticket number and Jira link

Please include the Jira Ticket Number and Link for this issue/task.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Ensure the target / base branch for any feature PR is set to `dev` not main (the only exception to this is releases from `dev` and hotfix branches)

## Checklist for conducting a review
- [ ] Review the code changes and make sure they all make sense and are necessary. 
- [ ] Pull the PR branch locally and test by running through workflow and making sure everything works as it is supposed to. 

## Workflow 

Owner of the Pull Request will be responsible for merge after all requirements are met, including approval from at least one reviewer. Additional changes made after a review will dismiss any approvals and require re-review of the additional updates. Auto merging can be enabled below if additional changes are likely not to be needed. The bot will auto assign reviewers to your Pull Request for you. 

