### PR TITLE
add standalone launch gateway

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -6,7 +6,7 @@ import theme from '../containers/styles/theme';
 import { ThemeProvider } from '@mui/styles';
 import Launch from '../containers/Launch';
 import Index from '../containers/Index';
-
+import Gateway from '../containers/Gateway/Gateway';
 const isGhPages = process.env.REACT_APP_GH_PAGES === 'true';
 const Router = isGhPages ? HashRouter : BrowserRouter;
 const redirect = isGhPages ? '/#/index' : '/index';
@@ -24,7 +24,7 @@ const App = () => {
             </ThemeProvider>
           }
         />
-        <Route path="/" exact element={<RequestBuilder redirect={redirect} />} />
+        <Route path="/" exact element={<Gateway redirect={redirect} />} />
       </Routes>
     </Router>
   );

--- a/src/containers/Gateway/Gateway.jsx
+++ b/src/containers/Gateway/Gateway.jsx
@@ -1,0 +1,119 @@
+import React, { memo, useState, useEffect } from 'react';
+import FHIR from 'fhirclient';
+import env from 'env-var';
+import {
+  Button,
+  FormControl,
+  FormHelperText,
+  IconButton,
+  TextField,
+  Accordion,
+  AccordionDetails
+} from '@mui/material';
+import Stack from '@mui/material/Stack';
+import Autocomplete from '@mui/material/Autocomplete';
+import useStyles from './styles';
+
+const Gateway = props => {
+  const classes = useStyles();
+  const envFhir = env.get('REACT_APP_EHR_SERVER').asString();
+  const envClient = env.get('REACT_APP_CLIENT').asString();
+  const envScope = env.get('REACT_APP_CLIENT_SCOPES').asString().split(' ');
+  const [clientId, setClientId] = useState(envClient || '');
+  const [fhirUrl, setFhirUrl] = useState(envFhir || '');
+  const [scope, _setScope] = useState(envScope || []);
+  const setScope = value => {
+    // split by space to facilitate copy/pasting strings of scopes into the input
+    const sv = value.map(e => {
+      if (e) {
+        return e.split(' ');
+      }
+    });
+    _setScope(sv.flat());
+  };
+  const submit = event => {
+    event.preventDefault();
+    FHIR.oauth2.authorize({
+      clientId: clientId,
+      scope: scope,
+      redirectUri: props.redirect,
+      iss: fhirUrl
+    });
+  };
+  return (
+    <div className={classes.gatewayDiv}>
+      <h2 className={classes.gatewayHeader}>Launch Request Generator</h2>
+      <form onSubmit={submit} autoComplete="off">
+        <FormControl fullWidth={true} required={true} margin="normal">
+          <Stack spacing={4} sx={{ width: '500px' }}>
+            <Autocomplete
+              freeSolo
+              filterSelectedOptions
+              id="iss-dropdown"
+              inputValue={fhirUrl}
+              onInputChange={(e, inputValue) => {
+                setFhirUrl(inputValue);
+              }}
+              options={[envFhir]} // TODO: can be updated later to include registered iss
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  size="medium"
+                  label="FHIR Server Endpoint"
+                  InputProps={{
+                    ...params.InputProps,
+                    type: 'search'
+                  }}
+                />
+              )}
+            />
+            <Autocomplete
+              freeSolo
+              filterSelectedOptions
+              id="client-dropdown"
+              inputValue={clientId}
+              onInputChange={(e, inputValue) => {
+                setClientId(inputValue);
+              }}
+              options={[envClient]} // TODO: can be updated later to match from iss from register page
+              renderInput={params => (
+                <TextField
+                  {...params}
+                  size="medium"
+                  label="Client ID"
+                  InputProps={{
+                    ...params.InputProps,
+                    type: 'search'
+                  }}
+                />
+              )}
+            />
+            <Autocomplete
+              multiple
+              freeSolo
+              limitTags={3}
+              disableClearable
+              filterSelectedOptions
+              id="tags-outlined"
+              options={envScope} // can be updated to include other scopes
+              value={scope}
+              onChange={(e, scopes) => {
+                // scopes is the new full list, not the singular new value
+                setScope(scopes);
+              }}
+              defaultValue={['launch']}
+              renderInput={params => (
+                <TextField {...params} label="Scope" placeholder="Enter Scope" />
+              )}
+            />
+            <Button type="submit" variant="outlined" disabled={clientId === '' || fhirUrl === ''}>
+              Launch
+            </Button>
+          </Stack>
+        </FormControl>
+      </form>
+    </div>
+  );
+};
+
+export default memo(Gateway);

--- a/src/containers/Gateway/Gateway.jsx
+++ b/src/containers/Gateway/Gateway.jsx
@@ -35,7 +35,7 @@ const Gateway = props => {
     event.preventDefault();
     FHIR.oauth2.authorize({
       clientId: clientId,
-      scope: scope,
+      scope: scope.join(' '),
       redirectUri: props.redirect,
       iss: fhirUrl
     });

--- a/src/containers/Gateway/styles.jsx
+++ b/src/containers/Gateway/styles.jsx
@@ -1,0 +1,27 @@
+import { makeStyles } from '@mui/styles';
+export default makeStyles(
+  theme => ({
+    '@global': {
+      body: {
+        backgroundColor: '#fafafa'
+      }
+    },
+    gatewayDiv: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      padding: '50px',
+      margin: '10% auto 0 auto',
+      width: '60%',
+      backgroundColor: '#fff'
+    },
+    gatewayHeader: {
+      marginBottom: '25px'
+    },
+    gatewayInput: {
+      padding: '50px'
+    }
+  }),
+
+  { name: 'Gateway', index: 1 }
+);

--- a/src/containers/Index.jsx
+++ b/src/containers/Index.jsx
@@ -12,13 +12,17 @@ const Index = props => {
     });
   }, []);
 
-  return <div>
-    { client ? <RequestBuilder client={client} /> : 
-      <div className='loading'>
-        <h1>Getting Client...</h1>
-      </div>
-    }
-    </div>;
+  return (
+    <div>
+      {client ? (
+        <RequestBuilder client={client} />
+      ) : (
+        <div className="loading">
+          <h1>Getting Client...</h1>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default Index;

--- a/src/containers/Launch.jsx
+++ b/src/containers/Launch.jsx
@@ -23,7 +23,11 @@ const Launch = props => {
     });
   }, []);
 
-  return <div className='loading'><h1>Launching...</h1></div>;
+  return (
+    <div className="loading">
+      <h1>Launching...</h1>
+    </div>
+  );
 };
 
 export default memo(Launch);


### PR DESCRIPTION
## Describe your changes

Adds a standalone launch page when opening the app on the base url.  When opening `localhost:3000` the app will show a form that allows the user to input the iss/client/scopes before launching.  Inputs default to the value in the env file so if you just want to connect to the regular ehr, you can launch immediately.  

You can test by changing the values in the inputs and seeing that it connects to the chosen ehr.  

There is some room here to connect with the client id registration task and have the dropdown menus include a list of iss/clients, and automatically loading the associated iss/client when you choose the counterpart.

## Issue ticket number and Jira link

[REMS-573](https://jira.mitre.org/browse/REMS-573)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Ensure the target / base branch for any feature PR is set to `dev` not main (the only exception to this is releases from `dev` and hotfix branches)

## Checklist for conducting a review
- [ ] Review the code changes and make sure they all make sense and are necessary. 
- [ ] Pull the PR branch locally and test by running through workflow and making sure everything works as it is supposed to. 

