### PR TITLE
remove potential for uncaught mismatch

### DIFF
--- a/src/containers/RequestBuilder.js
+++ b/src/containers/RequestBuilder.js
@@ -7,7 +7,7 @@ import '../index.css';
 import SettingsBox from '../components/SettingsBox/SettingsBox';
 import RequestBox from '../components/RequestBox/RequestBox';
 import buildRequest from '../util/buildRequest.js';
-import { types, defaultValues } from '../util/data.js';
+import { types, defaultValues, headerDefinitions } from '../util/data.js';
 import { createJwt, setupKeys } from '../util/auth';
 
 import env from 'env-var';
@@ -25,7 +25,7 @@ export default class RequestBuilder extends Component {
     this.state = {
       loading: false,
       logs: [],
-      patient: {}, 
+      patient: {},
       expanded: false,
       patientList: [],
       response: null,
@@ -38,26 +38,6 @@ export default class RequestBuilder extends Component {
       token: null,
       client: this.props.client,
       codeValues: defaultValues,
-      // Configurable values
-      alternativeTherapy: env.get('REACT_APP_ALT_DRUG').asBool(),
-      baseUrl: env.get('REACT_APP_EHR_BASE').asString(),
-      cdsUrl: env.get('REACT_APP_CDS_SERVICE').asString(),
-      defaultUser: env.get('REACT_APP_DEFAULT_USER').asString(),
-      ehrUrl: env.get('REACT_APP_EHR_SERVER').asString(),
-      ehrUrlSentToRemsAdminForPreFetch: env
-        .get('REACT_APP_EHR_SERVER_TO_BE_SENT_TO_REMS_ADMIN_FOR_PREFETCH')
-        .asString(),
-      generateJsonToken: env.get('REACT_APP_GENERATE_JWT').asBool(),
-      includeConfig: true,
-      launchUrl: env.get('REACT_APP_LAUNCH_URL').asString(),
-      orderSelect: env.get('REACT_APP_ORDER_SELECT').asString(),
-      orderSign: env.get('REACT_APP_ORDER_SIGN').asString(),
-      patientFhirQuery: env.get('REACT_APP_PATIENT_FHIR_QUERY').asString(),
-      patientView: env.get('REACT_APP_PATIENT_VIEW').asString(),
-      pimsUrl: env.get('REACT_APP_PIMS_SERVER').asString(),
-      responseExpirationDays: env.get('REACT_APP_RESPONSE_EXPIRATION_DAYS').asInt(),
-      sendPrefetch: true,
-      smartAppUrl: env.get('REACT_APP_SMART_LAUNCH_URL').asString()
     };
 
     this.updateStateElement = this.updateStateElement.bind(this);
@@ -69,12 +49,16 @@ export default class RequestBuilder extends Component {
   }
 
   componentDidMount() {
+    // init settings
+    Object.keys(headerDefinitions).map((key) => {
+      this.setState({ [key]: headerDefinitions[key].default });
+    });
     // load settings
     JSON.parse(localStorage.getItem('reqgenSettings') || '[]').forEach((element) => {
       try {
-        this.setState({[element[0]]: element[1]});
+        this.setState({ [element[0]]: element[1] });
       } catch {
-        if(element[0]){
+        if (element[0]) {
           console.log('Could not load setting:' + element[0]);
         }
       }
@@ -251,7 +235,7 @@ export default class RequestBuilder extends Component {
     });
   };
   handleChange = () => (event, isExpanded) => {
-    this.setState({ expanded: isExpanded ? true: false});
+    this.setState({ expanded: isExpanded ? true : false });
   };
 
   render() {
@@ -276,23 +260,23 @@ export default class RequestBuilder extends Component {
           </button>
         </div>
         <div>
-          <Modal open = {this.state.showSettings} onClose = {()=>{this.setState({showSettings:false});}} >
-            <div className = 'settings-box'>
+          <Modal open={this.state.showSettings} onClose={() => { this.setState({ showSettings: false }); }} >
+            <div className='settings-box'>
               <SettingsBox
                 state={this.state}
                 consoleLog={this.consoleLog}
                 updateCB={this.updateStateElement}
-              />         
+              />
             </div>
           </Modal>
         </div>
-          <div style={{display: 'flex'}}>
-            <Accordion style={{width: '95%'}} expanded={this.state.expanded} onChange={this.handleChange()}>
-              <AccordionSummary
+        <div style={{ display: 'flex' }}>
+          <Accordion style={{ width: '95%' }} expanded={this.state.expanded} onChange={this.handleChange()}>
+            <AccordionSummary
               expandIcon={<ExpandMoreIcon />}
               aria-controls="panel1a-content"
               id="panel1a-header"
-              style={{marginLeft: '45%'}}
+              style={{ marginLeft: '45%' }}
             >
               <Button variant="contained" startIcon={<PersonIcon />}>
                 Select a patient
@@ -302,37 +286,37 @@ export default class RequestBuilder extends Component {
               {this.state.patientList.length > 0 && this.state.expanded ?
                 <div>
                   <Box>
-                  {this.state.patientList instanceof Error
-                    ? this.renderError()
-                    : <PatientSearchBar
-                      getPatients = {this.getPatients}
-                      searchablePatients={this.state.patientList}
-                      client={this.props.client}
-                      callback={this.updateStateElement}
-                      callbackList={this.updateStateList}
-                      callbackMap={this.updateStateMap}
-                      // updatePrefetchCallback={PrefetchTemplate.generateQueries}
-                      clearCallback={this.clearState}
-                      ehrUrl={this.state.ehrUrl} // is this used?
-                      options={this.state.codeValues}
-                      responseExpirationDays={this.state.responseExpirationDays}
-                      defaultUser={this.state.defaultUser}
-                    />}
+                    {this.state.patientList instanceof Error
+                      ? this.renderError()
+                      : <PatientSearchBar
+                        getPatients={this.getPatients}
+                        searchablePatients={this.state.patientList}
+                        client={this.props.client}
+                        callback={this.updateStateElement}
+                        callbackList={this.updateStateList}
+                        callbackMap={this.updateStateMap}
+                        // updatePrefetchCallback={PrefetchTemplate.generateQueries}
+                        clearCallback={this.clearState}
+                        ehrUrl={this.state.ehrUrl} // is this used?
+                        options={this.state.codeValues}
+                        responseExpirationDays={this.state.responseExpirationDays}
+                        defaultUser={this.state.defaultUser}
+                      />}
                   </Box>
                 </div>
                 : <span></span>
               }
-              
+
             </AccordionDetails>
-            </Accordion>
-            <IconButton
-              color="primary"
-              onClick={() => this.getPatients()}
-              size="large"
-            >
-              <RefreshIcon fontSize="large" />
-            </IconButton>
-          </div>
+          </Accordion>
+          <IconButton
+            color="primary"
+            onClick={() => this.getPatients()}
+            size="large"
+          >
+            <RefreshIcon fontSize="large" />
+          </IconButton>
+        </div>
         <div className="form-group container left-form">
           <div>
             {/*for the ehr launch */}

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -1,71 +1,92 @@
+import env from 'env-var';
+
 const headerDefinitions = {
   alternativeTherapy: {
     display: 'Alternative Therapy Cards Allowed',
-    type: 'check'
+    type: 'check',
+    default: env.get('REACT_APP_ALT_DRUG').asBool()
   },
   baseUrl: {
     display: 'Base Server',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_EHR_BASE').asString()
   },
   cdsUrl: {
     display: 'REMS Admin',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_CDS_SERVICE').asString()
   },
   defaultUser: {
     display: 'Default User',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_DEFAULT_USER').asString()
   },
   ehrUrl: {
     display: 'EHR Server',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_EHR_SERVER').asString()
   },
   ehrUrlSentToRemsAdminForPreFetch: {
     display: 'EHR Server Sent to REMS Admin for Prefetch',
-    type: 'input'
+    type: 'input',
+    default: env
+    .get('REACT_APP_EHR_SERVER_TO_BE_SENT_TO_REMS_ADMIN_FOR_PREFETCH')
+    .asString()
   },
   generateJsonToken: {
     display: 'Generate JSON Web Token',
-    type: 'check'
+    type: 'check',
+    default: env.get('REACT_APP_GENERATE_JWT').asBool()
   },
   includeConfig: {
     display: 'Include Configuration in CRD Request',
-    type: 'check'
+    type: 'check',
+    default: true
   },
   launchUrl: {
     display: 'DTR Launch URL (QuestionnaireForm)',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_LAUNCH_URL').asString()
   },
   orderSelect: {
     display: 'Order Select Rest End Point',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_ORDER_SELECT').asString()
   },
   orderSign: {
     display: 'Order Sign Rest End Point',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_ORDER_SIGN').asString()
   },
   patientFhirQuery: {
     display: 'Patient FHIR Query',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_PATIENT_FHIR_QUERY').asString()
   },
   patientView: {
     display: 'Patient View Rest End Point',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_PATIENT_VIEW').asString()
   },
   pimsUrl: {
     display: 'PIMS Server',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_PIMS_SERVER').asString()
   },
   responseExpirationDays: {
     display: 'In Progress Form Expiration Days',
-    type: 'input'
+    type: 'input',
+    default: env.get('REACT_APP_RESPONSE_EXPIRATION_DAYS').asInt()
   },
   sendPrefetch: {
     display: 'Send Prefetch',
-    type: 'check'
+    type: 'check',
+    default: true
   },
   smartAppUrl: {
     display: 'SMART App',
-    type: 'input'
+    type: 'input',
+    default:  env.get('REACT_APP_SMART_LAUNCH_URL').asString()
   }
 };
 


### PR DESCRIPTION
This does not necessarily need to be pulled in, but could help address problems with our settings.  One issue we have is that we define the settings in two places, once in data.js as a definition, and then again in the RequestBuilder's state.  This produces the potential for a bug where the values between the two are mismatched, and since the SettingsBox only looks at the headerDefinitions, then tries to set the state, it could end up setting the state for a non-existent value.  This error would not produce an exception and the program would just appear to not work for no reason, making this a dangerous possible error.

The solution is to define one "source of truth" which I've done by pushing the headerDefinitions all into data.js, which RequestBuilder now uses to define its state.  The downside of this is that the RequestBuilder's state is now built dynamically, and can't be referenced directly (by intellisense, for example) meaning you might not know what exactly is in the state when programming.  A bug here WOULD produce an error, however, so it's easily detectable.  

In an idealized version of this fix, the state would hold its own definition of its settings, which would be passed to settingsBox as a prop, which would then render them.  This would require a bit of work, however, to restructure how the app uses and updates its settings, as well as how SettingsBox renders it.  

I don't think it's worth the effort to do all that, though.  In fact, even this change might not be worth it, given that it makes things less convenient in return for solving an issue that's very unlikely to occur.  

