### PR TITLE
prevent suggestions crash

### DIFF
--- a/src/components/DisplayBox/DisplayBox.js
+++ b/src/components/DisplayBox/DisplayBox.js
@@ -75,7 +75,7 @@ export default class DisplayBox extends Component {
     }
   }
 
-  supportedRequesType(resource) {
+  supportedRequestType(resource) {
     let resourceType = resource.resourceType.toUpperCase();
     if (
       resourceType === 'DEVICEREQUEST' ||
@@ -102,7 +102,9 @@ export default class DisplayBox extends Component {
         }
       } else {
         // disable this suggestion button if any are allowed
-        document.getElementById(buttonId).setAttribute('disabled', 'true');
+        const element = document.getElementById(buttonId);
+        element.setAttribute('disabled', 'true');
+        element.setAttribute('style', 'background-color:#4BB543;');
       }
 
       if (suggestion.label) {
@@ -131,7 +133,7 @@ export default class DisplayBox extends Component {
               console.log('suggested action CREATE result:');
               console.log(result);
 
-              if (this.supportedRequesType(result)) {
+              if (this.supportedRequestType(result)) {
                 // call into the request builder to resubmit the CRD request with the suggested request
                 this.props.takeSuggestion(result);
               }
@@ -398,11 +400,4 @@ export default class DisplayBox extends Component {
     }
   }
 
-  componentDidUpdate() {
-    // clear the suggestion buttons
-    console.log(this.buttonList);
-    this.buttonList.forEach((requestButton, id) => {
-      document.getElementById(requestButton)?.removeAttribute('disabled');
-    });
-  }
 }

--- a/src/components/DisplayBox/DisplayBox.js
+++ b/src/components/DisplayBox/DisplayBox.js
@@ -377,6 +377,7 @@ export default class DisplayBox extends Component {
                   </Typography>
                 </CardContent>
                 <CardActions className={'links-section'}>{linksSection}</CardActions>
+                <CardActions>{suggestionsSection}</CardActions>
               </React.Fragment>
             </Card>
           );
@@ -401,7 +402,7 @@ export default class DisplayBox extends Component {
     // clear the suggestion buttons
     console.log(this.buttonList);
     this.buttonList.forEach((requestButton, id) => {
-      document.getElementById(requestButton).removeAttribute('disabled');
+      document.getElementById(requestButton)?.removeAttribute('disabled');
     });
   }
 }

--- a/src/components/SMARTBox/PatientBox.js
+++ b/src/components/SMARTBox/PatientBox.js
@@ -465,7 +465,7 @@ export default class PatientBox extends Component {
       <TableContainer key={type} component={Paper} sx={{ blackgroundColor: '#ddd', border: '1px solid #535353' }}>
         <Table sx={{ maxHeight: 440, justifyContent: 'center' }} stickyHeader>
           <TableHead sx={{ borderBottom: '1px solid #535353'}}>
-            <TableRow>
+            <TableRow key="bingobongo">
               {columns.map((column) => (
                 <TableCell
                   key={column.id}
@@ -479,9 +479,8 @@ export default class PatientBox extends Component {
           </TableHead>
           <TableBody>
             {options.map((row) => (
-              <Tooltip title='Select Medication' arrow>
+              <Tooltip key={row.key} title='Select Medication' arrow>
                 <TableRow
-                  key={row.key}
                   sx={{ 'td, th': { border: 0 } }}
                   className='hover-row'
                   onClick={() => this.handleRequestChange(row.value, patient)}

--- a/src/components/SMARTBox/PatientBox.js
+++ b/src/components/SMARTBox/PatientBox.js
@@ -465,7 +465,7 @@ export default class PatientBox extends Component {
       <TableContainer key={type} component={Paper} sx={{ blackgroundColor: '#ddd', border: '1px solid #535353' }}>
         <Table sx={{ maxHeight: 440, justifyContent: 'center' }} stickyHeader>
           <TableHead sx={{ borderBottom: '1px solid #535353'}}>
-            <TableRow key="bingobongo">
+            <TableRow>
               {columns.map((column) => (
                 <TableCell
                   key={column.id}


### PR DESCRIPTION
For use with the REMS admin PR of the same name, makes suggestion buttons not error out when the card returns with suggestions.
