### PR TITLE
Update new state variable to open the snackbar as expected

### DIFF
--- a/src/components/RequestBox/RequestBox.js
+++ b/src/components/RequestBox/RequestBox.js
@@ -365,9 +365,9 @@ export default class RequestBox extends Component {
   }
 
   // SnackBar
-  handleRxResponse = () => this.setState({ open: true });
+  handleRxResponse = () => this.setState({ submittedRx: true });
 
-  handleClose = () => this.setState({ open: false });
+  handleClose = () => this.setState({ submittedRx: false });
 
   render() {
     const disableSendToCRD = this.isOrderNotSelected() || this.props.loading;


### PR DESCRIPTION
## Describe your changes

I noticed the 'submitted new Rx' snackbar stopped showing up. After looking at it, it seems the state variable that controls opening the snackbar got changed (from open to submittedRx) but the places where the variable was set to true was still setting 'open' and not 'submittedRx'. 

To Test:
Clear out PIMs and send new Rx to pharmacy, should see green snackbar at the bottom saying "Sucess! NewRx received by pharmacy' 

## Issue ticket number and Jira link

Small bug discovered - no JIRA ticket

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Ensure the target / base branch for any feature PR is set to `dev` not main (the only exception to this is releases from `dev` and hotfix branches)

## Checklist for conducting a review
- [ ] Review the code changes and make sure they all make sense and are necessary. 
- [ ] Pull the PR branch locally and test by running through workflow and making sure everything works as it is supposed to. 

## Workflow 

Owner of the Pull Request will be responsible for merge after all requirements are met, including approval from at least one reviewer. Additional changes made after a review will dismiss any approvals and require re-review of the additional updates. Auto merging can be enabled below if additional changes are likely not to be needed. The bot will auto assign reviewers to your Pull Request for you. 

