### PR TITLE
625 - Remove unused requests causing duplicate options

### DIFF
--- a/src/components/SMARTBox/PatientBox.js
+++ b/src/components/SMARTBox/PatientBox.js
@@ -210,37 +210,6 @@ const PatientBox = (props) => {
     }
   };
 
-  const getDeviceRequest = (patientId) => {
-    client
-      .request(`DeviceRequest?subject=Patient/${patientId}`, {
-        resolveReferences: ['subject', 'performer'],
-        graph: false,
-        flat: true
-      })
-      .then(result => {
-        setState(prevState => ({...prevState, deviceRequests: result}));
-        // now take results and make option
-        result.data.forEach(e => {
-          makeOption(e, state.options);
-        });
-      });
-  };
-
-  const getServiceRequest = (patientId) => {
-    client
-      .request(`ServiceRequest?subject=Patient/${patientId}`, {
-        resolveReferences: ['subject', 'performer'],
-        graph: false,
-        flat: true
-      })
-      .then(result => {
-        setState(prevState => ({...prevState, serviceRequests: result}));
-        result.data.forEach(e => {
-          makeOption(e, state.options);
-        });
-      });
-  };
-
   const getMedicationRequest = (patientId) => {
     client
       .request(`MedicationRequest?subject=Patient/${patientId}`, {
@@ -281,21 +250,6 @@ const PatientBox = (props) => {
           }
         });
         setState(prevState => ({...prevState, medicationRequests: result}));
-        result.data.forEach(e => {
-          makeOption(e, state.options);
-        });
-      });
-  };
-
-  const getMedicationDispense = (patientId) => {
-    client
-      .request(`MedicationDispense?subject=Patient/${patientId}`, {
-        resolveReferences: ['subject', 'performer'],
-        graph: false,
-        flat: true
-      })
-      .then(result => {
-        setState(prevState => ({...prevState, medicationDispenses: result}));
         result.data.forEach(e => {
           makeOption(e, state.options);
         });
@@ -355,10 +309,7 @@ const PatientBox = (props) => {
 
   const getRequests = () => {
     const patientId = patient.id;
-    getDeviceRequest(patientId);
-    getServiceRequest(patientId);
     getMedicationRequest(patientId);
-    getMedicationDispense(patientId);
   };
 
   /**


### PR DESCRIPTION
## Describe your changes

The multiple requests made was causing an extra option to show up by the MedicationDispense call. After checking with pat, these 3 calls are old and not used anymore. I got rid of the calls so now it displays the options for only the medication requests. 

## Issue ticket number and Jira link

https://jira.mitre.org/browse/REMS-625 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] Ensure the target / base branch for any feature PR is set to `dev` not main (the only exception to this is releases from `dev` and hotfix branches)

## Checklist for conducting a review
- [ ] Review the code changes and make sure they all make sense and are necessary. 
- [ ] Pull the PR branch locally and test by running through workflow and making sure everything works as it is supposed to. 

## Workflow 

Owner of the Pull Request will be responsible for merge after all requirements are met, including approval from at least one reviewer. Additional changes made after a review will dismiss any approvals and require re-review of the additional updates. Auto merging can be enabled below if additional changes are likely not to be needed. The bot will auto assign reviewers to your Pull Request for you. 

