### PR TITLE
Update etasu for medication reference

### DIFF
--- a/src/components/EtasuStatus/EtasuStatus.jsx
+++ b/src/components/EtasuStatus/EtasuStatus.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useContext } from 'react';
 import { SettingsContext } from '../../containers/ContextProvider/SettingsProvider.jsx';
 import { EtasuStatusComponent } from './EtasuStatusComponent.jsx';
 import { standardsBasedGetEtasu } from '../../util/util.js';
-import { createMedicationFromMedicationRequest } from '../../util/fhir.js';
+import { createMedicationFromMedicationRequest, getDrugCodeableConceptFromMedicationRequest } from '../../util/fhir.js';
 
 // converts code into etasu for the component to render
 // simplifies usage for applications that only know the code, not the case they want to display
@@ -22,7 +22,7 @@ export const EtasuStatus = props => {
   const getEtasuStatus = (medication) => {
     const body = makeBody(medication);
     setEtasuData(body);
-    const display = body.parameter[1]?.resource.code.coding[0].display;
+    const display = body.parameter[1]?.resource.code?.coding[0].display;
     setDisplay(display);
     const standardEtasuUrl = `${globalState.remsAdminServer}/4_0_0/GuidanceResponse/$rems-etasu`;
     standardsBasedGetEtasu(standardEtasuUrl, body, setRemsAdminResponse);

--- a/src/containers/RequestBuilder.jsx
+++ b/src/containers/RequestBuilder.jsx
@@ -122,7 +122,6 @@ const RequestBuilder = props => {
     let remsAdminUrls = [];
     // get all the remsAdminUrl for each MedicationRequest
     state.medicationRequests?.data?.forEach(request => {
-      const code = request?.medicationCodeableConcept?.coding[0]?.code;
       const remsAdminUrl = getMedicationSpecificRemsAdminUrl(request, globalState, hook);
       if (remsAdminUrl) {
         remsAdminUrls.push(remsAdminUrl);

--- a/src/util/fhir.js
+++ b/src/util/fhir.js
@@ -68,6 +68,17 @@ function createMedicationFromMedicationRequest(medicationRequest) {
   medication.id = medicationRequest?.id + '-med';
   if (medicationRequest.medicationCodeableConcept) {
     medication.code = medicationRequest.medicationCodeableConcept;
+  }  else if (medicationRequest.medicationReference) {
+    const reference = medicationRequest?.medicationReference;
+    medication.code = undefined;
+    medicationRequest?.contained?.every(e => {
+      if (e.resourceType + '/' + e.id === reference.reference) {
+        if (e.resourceType === 'Medication') {
+          console.log('Get Medication code from contained resource');
+          medication.code = e.code;
+        }
+      }
+    });
   }
   return medication;
 }

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { getDrugCodeableConceptFromMedicationRequest } from './fhir';
 
 /**
  * Retrieves a SMART launch context from an endpoint to append as a "launch" query parameter to a SMART app launch URL (see SMART docs for more about launch context).
@@ -96,8 +97,10 @@ const getMedicationSpecificRemsAdminUrl = (request, globalState, hook) => {
   if (Object.keys(request).length === 0) {
     return undefined;
   }
-  const display = request.medicationCodeableConcept?.coding?.[0]?.display;
-  const rxnorm = request.medicationCodeableConcept?.coding?.[0]?.code;
+
+  const codeableConcept = getDrugCodeableConceptFromMedicationRequest(request);
+  const display = codeableConcept?.coding?.[0]?.display;
+  const rxnorm = codeableConcept?.coding?.[0]?.code;
 
   if (!rxnorm) {
     console.log("ERROR: unknown MedicationRequest code: '", rxnorm);


### PR DESCRIPTION
## Describe your changes

When a medication request contains medicationreference instead of medication codableconcept it doesn't work. We need to handle when the MedicationRequest contains a medicationReference instead of a medicationCodeableConcept. 


Test case:  The Turalio MedicationRequest (pat036-mr-turalio) for Alice Smith (pat036) contains a medicationReference instead of a medicationCodeableConcept.
To Test:
Go through steps as normal for alice smiths's turalio medicaiton. Should see etasu status as expected.

## Issue ticket number and Jira link
https://jira.mitre.org/browse/REMS-668 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] Ensure the target / base branch for any feature PR is set to `dev` not main (the only exception to this is releases from `dev` and hotfix branches)

## Checklist for conducting a review
- [ ] Review the code changes and make sure they all make sense and are necessary. 
- [ ] Pull the PR branch locally and test by running through workflow and making sure everything works as it is supposed to. 

## Workflow 

Owner of the Pull Request will be responsible for merge after all requirements are met, including approval from at least one reviewer. Additional changes made after a review will dismiss any approvals and require re-review of the additional updates. Auto merging can be enabled below if additional changes are likely not to be needed. The bot will auto assign reviewers to your Pull Request for you. 

